### PR TITLE
Add calendar popup, F2 rename and Delete key shortcuts

### DIFF
--- a/src/components/Desktop.tsx
+++ b/src/components/Desktop.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'preact/hooks';
+import { useState, useEffect, useCallback, useRef } from 'preact/hooks';
 import type { PEInfo } from '../lib/pe';
 import type { MenuItem } from '../lib/pe/types';
 import { getRootItems, addFile, renameEntry, isFolder, displayName, getAllFiles, readDroppedItems } from '../lib/file-store';
@@ -22,6 +22,18 @@ export function Desktop({ onRunExe, onViewResources, onOpenFolder, onShowDisplay
   const fetchItems = useCallback(() => getRootItems(), []);
   const fm = useFolderTools('', fetchItems);
   const [dragOver, setDragOver] = useState(false);
+  const desktopRef = useRef<HTMLDivElement>(null);
+
+  function handleKeyDown(e: KeyboardEvent) {
+    if (!fm.selected || fm.editingName || fm.confirmDelete || fm.propertiesItem || fm.contextMenu || fm.bgContextMenu) return;
+    if (e.key === 'F2') {
+      e.preventDefault();
+      fm.setEditingName(fm.selected);
+    } else if (e.key === 'Delete') {
+      e.preventDefault();
+      fm.setConfirmDelete(fm.selected);
+    }
+  }
 
   // Auto-open from URL param on first load
   useEffect(() => {
@@ -86,9 +98,12 @@ export function Desktop({ onRunExe, onViewResources, onOpenFolder, onShowDisplay
 
   return (
     <div
+      ref={desktopRef}
+      tabIndex={-1}
       class="w-full select-none"
-      style={{ minHeight: '100%' }}
+      style={{ minHeight: '100%', outline: 'none' }}
       onClick={() => { if (fm.confirmDelete) return; fm.setSelected(null); fm.setEditingName(null); fm.setContextMenu(null); fm.setBgContextMenu(null); }}
+      onKeyDown={handleKeyDown}
       onContextMenu={(e: MouseEvent) => {
         if (fm.confirmDelete) { e.preventDefault(); return; }
         if (!(e.target as HTMLElement).closest('[data-desktop-icon]')) {
@@ -116,7 +131,7 @@ export function Desktop({ onRunExe, onViewResources, onOpenFolder, onShowDisplay
             isExe={f.isExe}
             selected={fm.selected === f.name}
             editing={fm.editingName === f.name}
-            onSelect={() => fm.setSelected(f.name)}
+            onSelect={() => { fm.setSelected(f.name); desktopRef.current?.focus(); }}
             onOpen={() => handleOpen(f.name, f.isFolder)}
             onRename={(newName) => fm.handleRename(f.name, newName)}
             onContextMenu={(e: MouseEvent) => { fm.setBgContextMenu(null); fm.setContextMenu({ x: e.clientX, y: e.clientY, item: f }); }}

--- a/src/components/FolderWindow.tsx
+++ b/src/components/FolderWindow.tsx
@@ -40,6 +40,19 @@ export function FolderWindow({
   const fetchItems = useCallback(() => getItemsInFolder(prefix), [prefix]);
   const fm = useFolderTools(prefix, fetchItems);
 
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  function handleKeyDown(e: KeyboardEvent) {
+    if (!fm.selected || fm.editingName || fm.confirmDelete || fm.propertiesItem || fm.contextMenu || fm.bgContextMenu) return;
+    if (e.key === 'F2') {
+      e.preventDefault();
+      fm.setEditingName(fm.selected);
+    } else if (e.key === 'Delete') {
+      e.preventDefault();
+      fm.setConfirmDelete(fm.selected);
+    }
+  }
+
   const [windowPos, setWindowPos] = useState({ x: 80 + Math.random() * 60, y: 40 + Math.random() * 40 });
   const [clientSize, setClientSize] = useState({ w: CLIENT_W, h: CLIENT_H });
   const [maximized, setMaximized] = useState(false);
@@ -166,8 +179,11 @@ export function FolderWindow({
         iconElement={FOLDER_ICON_16}
       >
         <div
-          style={{ width: '100%', height: '100%', overflow: 'auto', background: 'white' }}
+          ref={contentRef}
+          tabIndex={-1}
+          style={{ width: '100%', height: '100%', overflow: 'auto', background: 'white', outline: 'none' }}
           onClick={() => { fm.setSelected(null); fm.setContextMenu(null); fm.setBgContextMenu(null); }}
+          onKeyDown={handleKeyDown}
           onContextMenu={(e: MouseEvent) => {
             if (!(e.target as HTMLElement).closest('[data-desktop-icon]')) {
               e.preventDefault();
@@ -190,7 +206,7 @@ export function FolderWindow({
                 darkText
                 selected={fm.selected === item.name}
                 editing={fm.editingName === item.name}
-                onSelect={() => fm.setSelected(item.name)}
+                onSelect={() => { fm.setSelected(item.name); contentRef.current?.focus(); }}
                 onOpen={() => handleOpen(item)}
                 onRename={(newName) => fm.handleRename(item.name, newName)}
                 onContextMenu={(e: MouseEvent) => {

--- a/src/components/win2k/CalendarPopup.tsx
+++ b/src/components/win2k/CalendarPopup.tsx
@@ -1,0 +1,104 @@
+import { useState, useEffect } from 'preact/hooks';
+
+export function CalendarPopup() {
+  const [now, setNow] = useState(new Date());
+  const [viewYear, setViewYear] = useState(() => new Date().getFullYear());
+  const [viewMonth, setViewMonth] = useState(() => new Date().getMonth());
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const timeStr = now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+
+  // Localized narrow day names starting from Monday
+  const dayHeaders = Array.from({ length: 7 }, (_, i) => {
+    const d = new Date(2024, 0, 1 + i); // 2024-01-01 = Monday
+    return d.toLocaleDateString(undefined, { weekday: 'narrow' });
+  });
+
+  const monthLabel = new Date(viewYear, viewMonth, 1)
+    .toLocaleDateString(undefined, { month: 'long', year: 'numeric' });
+
+  const daysInMonth = new Date(viewYear, viewMonth + 1, 0).getDate();
+  const firstDow = new Date(viewYear, viewMonth, 1).getDay(); // 0=Sun
+  const startOffset = (firstDow + 6) % 7; // Monday-based
+
+  const today = new Date();
+  const isToday = (day: number) =>
+    viewYear === today.getFullYear() && viewMonth === today.getMonth() && day === today.getDate();
+
+  // Build grid with prev/next month filler days
+  const cells: { day: number; current: boolean }[] = [];
+  const prevMonthDays = new Date(viewYear, viewMonth, 0).getDate();
+  for (let i = startOffset - 1; i >= 0; i--) cells.push({ day: prevMonthDays - i, current: false });
+  for (let d = 1; d <= daysInMonth; d++) cells.push({ day: d, current: true });
+  let nextDay = 1;
+  while (cells.length % 7 !== 0) cells.push({ day: nextDay++, current: false });
+
+  function prevMonthNav() {
+    if (viewMonth === 0) { setViewMonth(11); setViewYear(y => y - 1); }
+    else setViewMonth(m => m - 1);
+  }
+  function nextMonthNav() {
+    if (viewMonth === 11) { setViewMonth(0); setViewYear(y => y + 1); }
+    else setViewMonth(m => m + 1);
+  }
+
+  const navBtn: Record<string, string | number> = {
+    cursor: 'var(--win2k-cursor)',
+    display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+    width: '18px', height: '18px',
+    background: '#D4D0C8', border: '1px solid',
+    borderColor: '#FFF #404040 #404040 #FFF',
+    fontSize: '8px',
+  };
+
+  return (
+    <div
+      onPointerDown={(e: Event) => e.stopPropagation()}
+      style={{
+        position: 'fixed', bottom: '32px', right: '4px',
+        background: '#D4D0C8',
+        border: '2px solid', borderColor: '#FFF #404040 #404040 #FFF',
+        padding: '8px', zIndex: 10001,
+        font: '11px "Tahoma", "MS Sans Serif", sans-serif',
+        userSelect: 'none',
+      }}
+    >
+      {/* Time with seconds */}
+      <div style={{
+        textAlign: 'center', fontSize: '18px',
+        fontFamily: '"Courier New", monospace',
+        padding: '2px 0 6px', fontWeight: 'bold',
+        borderBottom: '1px solid #808080', marginBottom: '6px',
+      }}>
+        {timeStr}
+      </div>
+
+      {/* Month navigation */}
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '4px' }}>
+        <span onClick={prevMonthNav} style={navBtn}>◀</span>
+        <span style={{ fontWeight: 'bold', textTransform: 'capitalize' }}>{monthLabel}</span>
+        <span onClick={nextMonthNav} style={navBtn}>▶</span>
+      </div>
+
+      {/* Calendar grid */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 24px)', textAlign: 'center' }}>
+        {dayHeaders.map((d, i) => (
+          <div key={i} style={{ fontWeight: 'bold', padding: '2px 0', fontSize: '10px', color: '#808080' }}>{d}</div>
+        ))}
+        {cells.map((cell, i) => (
+          <div key={i} style={{
+            padding: '2px 0', fontSize: '11px', lineHeight: '16px',
+            color: cell.current ? '#000' : '#C0C0C0',
+            ...(cell.current && isToday(cell.day) ? { background: '#000080', color: '#FFF' } : {}),
+          }}>
+            {cell.day}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/win2k/Taskbar.tsx
+++ b/src/components/win2k/Taskbar.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'preact/hooks';
 import type { ComponentChildren } from 'preact';
 import type { MenuItem } from '../../lib/pe/types';
 import { MenuDropdown } from './MenuBar';
+import { CalendarPopup } from './CalendarPopup';
 import { t } from '../../lib/regional-settings';
 
 interface TaskbarApp {
@@ -52,6 +53,7 @@ export function Taskbar({ runningApps, focusedAppId, onActivateApp, onMinimizeAp
   const [bgContextMenu, setBgContextMenu] = useState<{ x: number; y: number } | null>(null);
   const [startOpen, setStartOpen] = useState(false);
   const [startPos, setStartPos] = useState<{ x: number; y: number } | null>(null);
+  const [calendarOpen, setCalendarOpen] = useState(false);
 
   const handleContextMenu = useCallback((e: MouseEvent, appId: number) => {
     e.preventDefault();
@@ -62,11 +64,11 @@ export function Taskbar({ runningApps, focusedAppId, onActivateApp, onMinimizeAp
   const dismissMenu = useCallback(() => setContextMenu(null), []);
 
   useEffect(() => {
-    if (!contextMenu && !bgContextMenu && !startOpen) return;
-    const onDown = () => { setContextMenu(null); setBgContextMenu(null); setStartOpen(false); };
+    if (!contextMenu && !bgContextMenu && !startOpen && !calendarOpen) return;
+    const onDown = () => { setContextMenu(null); setBgContextMenu(null); setStartOpen(false); setCalendarOpen(false); };
     const timer = setTimeout(() => document.addEventListener('pointerdown', onDown), 0);
     return () => { clearTimeout(timer); document.removeEventListener('pointerdown', onDown); };
-  }, [contextMenu, bgContextMenu, startOpen]);
+  }, [contextMenu, bgContextMenu, startOpen, calendarOpen]);
 
   const contextApp = contextMenu ? runningApps.find(a => a.id === contextMenu.appId) : null;
 
@@ -95,7 +97,7 @@ export function Taskbar({ runningApps, focusedAppId, onActivateApp, onMinimizeAp
             const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
             setStartPos({ x: rect.left, y: rect.top });
             setStartOpen(prev => !prev);
-            setContextMenu(null); setBgContextMenu(null);
+            setContextMenu(null); setBgContextMenu(null); setCalendarOpen(false);
           }}
           style={{
             display: 'flex', alignItems: 'center', gap: '3px',
@@ -192,8 +194,18 @@ export function Taskbar({ runningApps, focusedAppId, onActivateApp, onMinimizeAp
             <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/>
           </svg>
         </a>
-        <Clock />
+        <span
+          onDblClick={(e: Event) => {
+            e.stopPropagation();
+            setCalendarOpen(o => !o);
+          }}
+          style={{ cursor: 'var(--win2k-cursor)', padding: '0 2px' }}
+        >
+          <Clock />
+        </span>
       </div>
+
+      {calendarOpen && <CalendarPopup />}
 
       {/* Taskbar background context menu */}
       {bgContextMenu && (() => {


### PR DESCRIPTION
 ### Summary

  - Double-clicking the taskbar clock opens a Win2k-styled calendar popup showing live time with seconds, monthly calendar with navigation, and localized day/month names
  - Pressing F2 on a selected desktop or folder icon enters rename mode
  - Pressing Delete on a selected desktop or folder icon triggers the delete confirmation dialog (same as right-click > Delete)

###  Test plan

  - Double-click the clock in the taskbar → calendar popup appears above the clock
  - Calendar shows current time with seconds, updating live
  - Navigate months with ◀/▶ arrows, today is highlighted in blue
  - Click outside the popup to dismiss it
  - Select a desktop icon, press F2 → rename input appears
  - Select a desktop icon, press Delete → delete confirmation dialog appears
  - Same F2/Delete shortcuts work inside folder windows
  - Shortcuts don't fire during rename editing, delete dialog, or context menus