### PR TITLE
 Search DLLs in PATH directories when not found in exe's directory

### DIFF
--- a/src/components/EmulatorView.tsx
+++ b/src/components/EmulatorView.tsx
@@ -569,27 +569,6 @@ export function EmulatorView({ arrayBuffer, peInfo, additionalFiles, exeName, co
         }
       });
 
-      // Enable WASM JIT if configured in DOS Settings
-      if (emu.isDOS) emu.wasmJitEnabled = loadDosSettings().jitEnabled;
-
-      // Assign shared AudioContext — created in App during user gesture
-      if (sharedAudioContext) {
-        emu.audioContext = sharedAudioContext;
-        if (emu.isDOS) emu.dosAudio.init(sharedAudioContext);
-      }
-
-      // Console app detection
-      if (emu.isConsole) {
-        setIsConsole(true);
-        setWindowReady(true);
-        if (!emu.consoleTitle) emu.consoleTitle = emu.exePath;
-        setWindowTitle(emu.consoleTitle);
-        onTitleChange?.(emu.consoleTitle);
-        setWindowStyle(WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX);
-        setCanvasSize({ w: 640, h: 480 });
-        onReady?.();
-      }
-
       emu.onConsoleTitleChange = () => {
         setWindowTitle(emu.consoleTitle);
         onTitleChange?.(emu.consoleTitle);
@@ -771,6 +750,27 @@ export function EmulatorView({ arrayBuffer, peInfo, additionalFiles, exeName, co
 
       // Load registry from IndexedDB then start
       initAndRun().then(() => {
+        // Enable WASM JIT if configured in DOS Settings
+        if (emu.isDOS) emu.wasmJitEnabled = loadDosSettings().jitEnabled;
+
+        // Assign shared AudioContext — created in App during user gesture
+        if (sharedAudioContext) {
+          emu.audioContext = sharedAudioContext;
+          if (emu.isDOS) emu.dosAudio.init(sharedAudioContext);
+        }
+
+        // Console app detection (must be after load() which sets isDOS/isConsole)
+        if (emu.isConsole) {
+          setIsConsole(true);
+          setWindowReady(true);
+          if (!emu.consoleTitle) emu.consoleTitle = emu.exePath;
+          setWindowTitle(emu.consoleTitle);
+          onTitleChange?.(emu.consoleTitle);
+          setWindowStyle(WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX);
+          setCanvasSize({ w: 640, h: 480 });
+          onReady?.();
+        }
+
         emu.run();
         if (emu.missingDlls.length > 0) {
           const s = t();

--- a/src/components/EmulatorView.tsx
+++ b/src/components/EmulatorView.tsx
@@ -485,6 +485,16 @@ export function EmulatorView({ arrayBuffer, peInfo, additionalFiles, exeName, co
         }, 500);
       };
       emu.profileStore = profStore;
+
+      // Populate virtual filesystem before load() so NE DLL PATH search can find files
+      const allFiles = await getAllFiles();
+      emu.fs.virtualFiles = allFiles.map(f => ({ name: f.name, size: f.data.byteLength }));
+      const cache = (emu.fs as any).virtualFileCache as Map<string, ArrayBuffer> | undefined;
+      if (cache) {
+        for (const f of allFiles) cache.set(f.name.toUpperCase(), f.data);
+      }
+
+      await emu.load(arrayBuffer, peInfo, canvas);
     };
 
     try {
@@ -517,9 +527,30 @@ export function EmulatorView({ arrayBuffer, peInfo, additionalFiles, exeName, co
       }
       emu.screenWidth = window.innerWidth;
       emu.screenHeight = window.innerHeight;
+
+      // Wire up async file I/O to IndexedDB via FileManager (before load() so
+      // NE DLL loading can fetch DLLs from PATH directories in IndexedDB)
+      emu.fs.onFileRequest = (fileName: string) => getFile(fileName);
+      emu.fs.onFileSave = (fileName: string, data: ArrayBuffer) => {
+        addFile(fileName, data).then(() => window.dispatchEvent(new Event('desktop-files-changed')));
+      };
+      emu.fs.onFileDelete = (fileName: string) => {
+        deleteFile(fileName).then(() => window.dispatchEvent(new Event('desktop-files-changed')));
+      };
+
+      // Wire up browser download for Z:\ file save
+      emu.fs.onFileSaveExternal = (name, data) => {
+        const blob = new Blob([data]);
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = name;
+        a.click();
+        setTimeout(() => URL.revokeObjectURL(url), 1000);
+      };
+
       onSetupEmulator?.(emu);
 
-      emu.load(arrayBuffer, peInfo, canvas);
       emuRef.current = emu;
       onRegisterCloseHandler?.(() => {
         if (emu.mainWindow) {
@@ -554,36 +585,6 @@ export function EmulatorView({ arrayBuffer, peInfo, additionalFiles, exeName, co
         setWindowTitle(emu.consoleTitle);
         onTitleChange?.(emu.consoleTitle);
       };
-
-      // Wire up async file I/O to IndexedDB via FileManager
-      emu.fs.onFileRequest = (fileName: string) => getFile(fileName);
-      emu.fs.onFileSave = (fileName: string, data: ArrayBuffer) => {
-        addFile(fileName, data).then(() => window.dispatchEvent(new Event('desktop-files-changed')));
-      };
-      emu.fs.onFileDelete = (fileName: string) => {
-        deleteFile(fileName).then(() => window.dispatchEvent(new Event('desktop-files-changed')));
-      };
-
-      // Wire up browser download for Z:\ file save
-      emu.fs.onFileSaveExternal = (name, data) => {
-        const blob = new Blob([data]);
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = name;
-        a.click();
-        setTimeout(() => URL.revokeObjectURL(url), 1000);
-      };
-
-      // Populate virtual filesystem with desktop files (for all app types)
-      getAllFiles().then(files => {
-        emu.fs.virtualFiles = files.map(f => ({ name: f.name, size: f.data.byteLength }));
-        // Pre-populate data cache so file reads don't need another IndexedDB round-trip
-        const cache = (emu.fs as any).virtualFileCache as Map<string, ArrayBuffer> | undefined;
-        if (cache) {
-          for (const f of files) cache.set(f.name.toUpperCase(), f.data);
-        }
-      });
 
       // Listen for window changes from emulator
       emu.onWindowChange = (wnd: WindowInfo) => {
@@ -658,7 +659,7 @@ export function EmulatorView({ arrayBuffer, peInfo, additionalFiles, exeName, co
       };
 
       // Child console process from console parent: run in-process, share console
-      emu.onCreateChildConsole = (childExeName: string, childCmdLine: string, hProcess: number) => {
+      emu.onCreateChildConsole = async (childExeName: string, childCmdLine: string, hProcess: number) => {
         const lowerName = childExeName.toLowerCase();
         let childData: ArrayBuffer | undefined;
         let childFileName = childExeName;
@@ -701,7 +702,7 @@ export function EmulatorView({ arrayBuffer, peInfo, additionalFiles, exeName, co
         }
 
         // Load child (this creates its own consoleBuffer via initConsoleBuffer)
-        childEmu.load(childData, childPeInfo, canvas);
+        await childEmu.load(childData, childPeInfo, canvas);
         if (childEmu.isDOS) childEmu.wasmJitEnabled = loadDosSettings().jitEnabled;
 
         // Share console state AFTER load() so initConsoleBuffer doesn't overwrite

--- a/src/components/EmulatorView.tsx
+++ b/src/components/EmulatorView.tsx
@@ -447,6 +447,19 @@ export function EmulatorView({ arrayBuffer, peInfo, additionalFiles, exeName, co
     const emu = new Emulator();
     emu.configuredLcid = loadSettings().localeId;
 
+    // Sync virtual filesystem from IndexedDB into the emulator's FileManager
+    const syncVirtualFiles = async (e: Emulator) => {
+      const files = await getAllFiles();
+      e.fs.virtualFiles = files.map(f => ({ name: f.name, size: f.data.byteLength }));
+      const cache = (e.fs as { virtualFileCache?: Map<string, ArrayBuffer> }).virtualFileCache;
+      if (cache) {
+        cache.clear();
+        for (const f of files) cache.set(f.name.toUpperCase(), f.data);
+      }
+    };
+    const onDesktopChanged = () => { syncVirtualFiles(emu); };
+    window.addEventListener('desktop-files-changed', onDesktopChanged);
+
     // Async init for registry + profiles, then start emulator
     let regFlushTimer: ReturnType<typeof setTimeout> | null = null;
     let profFlushTimer: ReturnType<typeof setTimeout> | null = null;
@@ -488,12 +501,7 @@ export function EmulatorView({ arrayBuffer, peInfo, additionalFiles, exeName, co
       emu.profileStore = profStore;
 
       // Populate virtual filesystem before load() so NE DLL PATH search can find files
-      const allFiles = await getAllFiles();
-      emu.fs.virtualFiles = allFiles.map(f => ({ name: f.name, size: f.data.byteLength }));
-      const cache = (emu.fs as any).virtualFileCache as Map<string, ArrayBuffer> | undefined;
-      if (cache) {
-        for (const f of allFiles) cache.set(f.name.toUpperCase(), f.data);
-      }
+      await syncVirtualFiles(emu);
 
       await emu.load(arrayBuffer, peInfo, canvas);
     };
@@ -780,6 +788,7 @@ export function EmulatorView({ arrayBuffer, peInfo, additionalFiles, exeName, co
     }
 
     return () => {
+      window.removeEventListener('desktop-files-changed', onDesktopChanged);
       if (regFlushTimer !== null) clearTimeout(regFlushTimer);
       if (emuRef.current) {
         if (processRegistry && emuRef.current.pid) {

--- a/src/lib/emu/emu-exec.ts
+++ b/src/lib/emu/emu-exec.ts
@@ -1168,7 +1168,7 @@ export function emuTick(emu: Emulator): void {
   _diagTickCount++;
   _diagTickTotalMs += performance.now() - tickStart;
   const now2 = performance.now();
-  if (now2 - _diagLastLog > 2000) {
+  if (emu.wasmJitEnabled && now2 - _diagLastLog > 2000) {
     console.log(`[WASM-DIAG] ${_diagTickCount} ticks in ${_diagTickTotalMs.toFixed(0)}ms | WASM: ${_diagWasmRuns} runs, ${_diagWasmInsns} insns | Interp: ${_diagInterpInsns} insns | exits: ${JSON.stringify(_diagWasmExits)} | avg tick: ${(_diagTickTotalMs/_diagTickCount).toFixed(1)}ms | use32=${emu.cpu.use32} realMode=${emu.cpu.realMode}`);
     _diagWasmRuns = 0; _diagWasmInsns = 0; _diagInterpInsns = 0;
     _diagWasmExits = {}; _diagTickCount = 0; _diagTickTotalMs = 0;

--- a/src/lib/emu/emu-load.ts
+++ b/src/lib/emu/emu-load.ts
@@ -127,7 +127,7 @@ function topoSortDlls(entries: DllEntry[], loadedSet: Set<string>): DllEntry[] {
   return result;
 }
 
-export function emuLoad(emu: Emulator, arrayBuffer: ArrayBuffer, peInfo: PEInfo, canvas: HTMLCanvasElement): void {
+export async function emuLoad(emu: Emulator, arrayBuffer: ArrayBuffer, peInfo: PEInfo, canvas: HTMLCanvasElement): Promise<void> {
   console.log('[EMU] load() called, arrayBuffer size:', arrayBuffer.byteLength);
   emu.arrayBuffer = arrayBuffer;
   emu.peInfo = peInfo;
@@ -284,7 +284,7 @@ export function emuLoad(emu: Emulator, arrayBuffer: ArrayBuffer, peInfo: PEInfo,
     emu.localHeapEnd = emu.localHeapBase + heapMax;
 
     // Load NE DLLs referenced by the main exe (before setting heap base)
-    const neDllEntries = loadNEDlls(emu);
+    const neDllEntries = await loadNEDlls(emu);
 
     // Global heap/virtual allocator after all NE segments (exe + DLLs)
     // nextSelector * 0x10000 is the next linear address after all segments
@@ -813,8 +813,48 @@ interface NEDllEntry {
   heapSize: number;
 }
 
+/** Search for a DLL in PATH directories via the FileManager. */
+async function findNEDllInPath(emu: Emulator, modName: string): Promise<ArrayBuffer | undefined> {
+  const pathEnv = emu.envVars.get('PATH') ?? '';
+  if (!pathEnv) return undefined;
+  const fs = emu.fs;
+  const dirs = pathEnv.split(';');
+  const modLower = modName.toLowerCase();
+  for (const dir of dirs) {
+    if (!dir) continue;
+    const sep = dir.endsWith('\\') ? '' : '\\';
+    for (const ext of ['.dll', '.ocx', '.vbx', '.drv']) {
+      const fullPath = dir + sep + modLower + ext;
+      const fileInfo = fs.findFile(fullPath, emu.additionalFiles);
+      if (!fileInfo) continue;
+      // Try synchronous sources first
+      if (fileInfo.source === 'additional') {
+        const data = emu.additionalFiles.get(fileInfo.name);
+        if (data) {
+          console.log(`[NE DLL] Found ${modName} in PATH dir ${dir}`);
+          return data;
+        }
+      } else if (fileInfo.source === 'external') {
+        const ext2 = fs.externalFiles.get(fullPath.toUpperCase());
+        if (ext2) {
+          console.log(`[NE DLL] Found ${modName} in PATH dir ${dir}`);
+          return ext2.data.buffer.slice(ext2.data.byteOffset, ext2.data.byteOffset + ext2.data.byteLength) as ArrayBuffer;
+        }
+      } else if (fileInfo.source === 'virtual') {
+        // Fetch from IndexedDB (async)
+        const buf = await fs.fetchFileData(fileInfo, emu.additionalFiles, fullPath);
+        if (buf) {
+          console.log(`[NE DLL] Found ${modName} in PATH dir ${dir} (IndexedDB)`);
+          return buf;
+        }
+      }
+    }
+  }
+  return undefined;
+}
+
 /** Load NE DLLs referenced by the main NE exe. Returns DLL entry points to call. */
-function loadNEDlls(emu: Emulator): NEDllEntry[] {
+async function loadNEDlls(emu: Emulator): Promise<NEDllEntry[]> {
   if (!emu.ne) return [];
 
   const ne = emu.ne;
@@ -851,8 +891,12 @@ function loadNEDlls(emu: Emulator): NEDllEntry[] {
       }
       if (dllBuf) break;
     }
+    // If not in additionalFiles, search PATH directories via FileManager
     if (!dllBuf) {
-      console.warn(`[NE DLL] Module ${modName} not found in additionalFiles`);
+      dllBuf = await findNEDllInPath(emu, modName);
+    }
+    if (!dllBuf) {
+      console.warn(`[NE DLL] Module ${modName} not found`);
       emu.missingDlls.push(modName);
       continue;
     }

--- a/src/lib/emu/emulator.ts
+++ b/src/lib/emu/emulator.ts
@@ -501,7 +501,7 @@ export class Emulator {
   /** Environment variable store (uppercase key → value), shared by kernel32 and msvcrt */
   envVars = new Map<string, string>([
     ['COMSPEC',                  'C:\\WINDOWS\\SYSTEM32\\CMD.EXE'],
-    ['PATH',                     'C:\\WINDOWS\\SYSTEM32;C:\\WINDOWS;C:\\WINDOWS\\SYSTEM32\\WBEM'],
+    ['PATH',                     'D:\\DOS;C:\\DOS;D:\\WINDOWS;C:\\WINDOWS;D:\\WINDOWS\\SYSTEM;C:\\WINDOWS\\SYSTEM;D:\\WINDOWS\\SYSTEM32;C:\\WINDOWS\\SYSTEM32;D:\\WINDOWS\\SYSTEM32\\WBEM;C:\\WINDOWS\\SYSTEM32\\WBEM'],
     ['PATHEXT',                  '.COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC'],
     ['SYSTEMROOT',               'C:\\WINDOWS'],
     ['SYSTEMDRIVE',              'C:'],
@@ -986,9 +986,9 @@ export class Emulator {
   }
 
   // Delegated to emu-load.ts
-  load(arrayBuffer: ArrayBuffer, peInfo: PEInfo, canvas: HTMLCanvasElement): void {
+  async load(arrayBuffer: ArrayBuffer, peInfo: PEInfo, canvas: HTMLCanvasElement): Promise<void> {
     this._arrayBuffer = arrayBuffer;
-    emuLoad(this, arrayBuffer, peInfo, canvas);
+    await emuLoad(this, arrayBuffer, peInfo, canvas);
   }
 
   findResourceEntry(typeId: number | string, nameId: number | string): { dataRva: number; dataSize: number } | null {

--- a/src/lib/emu/win32/kernel32/module.ts
+++ b/src/lib/emu/win32/kernel32/module.ts
@@ -5,7 +5,8 @@ import { parsePE, extractExports } from '../../../pe';
 
 import { buildThunkTable } from '../../emu-thunks-pe';
 import { rebuildThunkPages } from '../../emu-load';
-import { emuCallDllMain } from '../../emu-exec';
+import { emuCallDllMain, emuCompleteThunk } from '../../emu-exec';
+import type { FileInfo } from '../../file-manager';
 
 // Module-level type no longer needed — exports are stored on emu.loadedDllExports
 
@@ -117,7 +118,112 @@ function hasRegisteredApis(emu: Emulator, dllName: string): boolean {
   return false;
 }
 
-function loadDll(emu: Emulator, rawName: string): number {
+/** Result of PATH search: either sync data or a pending async fetch. */
+interface PathSearchPending {
+  pending: true;
+  fileInfo: FileInfo;
+  fullPath: string;
+  dir: string;
+}
+type PathSearchResult = ArrayBuffer | PathSearchPending | undefined;
+
+/**
+ * Search for a DLL in PATH directories via the FileManager.
+ * Returns ArrayBuffer (sync), PathSearchPending (needs async fetch), or undefined (not found).
+ */
+function findDllInPath(emu: Emulator, basename: string): PathSearchResult {
+  const pathEnv = emu.envVars.get('PATH') ?? '';
+  if (!pathEnv) return undefined;
+  const fs = emu.fs;
+  const dirs = pathEnv.split(';');
+  for (const dir of dirs) {
+    if (!dir) continue;
+    const sep = dir.endsWith('\\') ? '' : '\\';
+    const fullPath = dir + sep + basename;
+    const fileInfo = fs.findFile(fullPath, emu.additionalFiles);
+    if (!fileInfo) continue;
+    // Try to get data synchronously
+    if (fileInfo.source === 'additional') {
+      const data = emu.additionalFiles.get(fileInfo.name);
+      if (data) {
+        console.log(`[LoadLibrary] Found "${basename}" in PATH dir ${dir}`);
+        return data;
+      }
+    } else if (fileInfo.source === 'external') {
+      const ext = fs.externalFiles.get(fullPath.toUpperCase());
+      if (ext) {
+        console.log(`[LoadLibrary] Found "${basename}" in PATH dir ${dir}`);
+        return ext.data.buffer.slice(ext.data.byteOffset, ext.data.byteOffset + ext.data.byteLength) as ArrayBuffer;
+      }
+    } else if (fileInfo.source === 'virtual') {
+      // Check in-memory cache first
+      const dfm = fs as { virtualFileCache?: Map<string, ArrayBuffer> };
+      if (dfm.virtualFileCache) {
+        const cached = dfm.virtualFileCache.get(fileInfo.name.toUpperCase());
+        if (cached) {
+          console.log(`[LoadLibrary] Found "${basename}" in PATH dir ${dir} (cached)`);
+          return cached;
+        }
+      }
+      // Not cached — return pending so caller can fetch async from IndexedDB
+      console.log(`[LoadLibrary] Found "${basename}" in PATH dir ${dir} (async fetch needed)`);
+      return { pending: true, fileInfo, fullPath, dir };
+    }
+  }
+  return undefined;
+}
+
+/** Load a DLL PE buffer into the emulator. Returns the base address. */
+function loadDllFromBuffer(emu: Emulator, ab: ArrayBuffer, rawName: string, basename: string): number {
+  // Detect address conflicts before loading
+  const { imageBase: preferred, sizeOfImage: dllSize } = parsePEHeader(ab);
+  const occupiedRanges: { base: number; size: number }[] = [];
+  occupiedRanges.push({ base: emu.pe.imageBase, size: emu.pe.sizeOfImage });
+  for (const [, mod] of emu.loadedModules) {
+    occupiedRanges.push({ base: mod.base, size: mod.sizeOfImage ?? 0x100000 });
+  }
+  let actualBase = preferred;
+  for (const r of occupiedRanges) {
+    if (actualBase < r.base + r.size && actualBase + dllSize > r.base) {
+      actualBase = ((r.base + r.size + 0xFFFF) & ~0xFFFF) >>> 0;
+    }
+  }
+  const baseOverride = actualBase !== preferred ? actualBase : undefined;
+
+  // Load DLL PE into emulator memory
+  const pe = loadPE(ab, emu.memory, baseOverride);
+
+  // Build thunks for the DLL's own imports (it imports from kernel32, user32, etc.)
+  const savedPe = emu.pe;
+  emu.pe = pe;
+  buildThunkTable(emu);
+  emu.pe = savedPe;
+  rebuildThunkPages(emu);
+
+  // Extract export table
+  const peInfo = parsePE(ab);
+  const exportResult = extractExports(peInfo, ab);
+  const exportFuncs = exportResult?.functions ?? [];
+
+  emu.loadedDllExports.set(basename, { base: pe.imageBase, exports: exportFuncs });
+  emu.loadedModules.set(basename, { base: pe.imageBase, resourceRva: pe.resourceRva, imageBase: pe.imageBase, sizeOfImage: pe.sizeOfImage });
+
+  console.log(`[LoadLibrary] Loaded "${rawName}" at 0x${pe.imageBase.toString(16)}, ${exportFuncs.length} exports`);
+
+  // Resolve transitive dependencies
+  if (emu.additionalFiles.size > 0) {
+    resolveSubDllImports(emu, pe);
+  }
+
+  // Call DllMain(DLL_PROCESS_ATTACH)
+  if (pe.entryPoint && pe.entryPoint !== pe.imageBase) {
+    emuCallDllMain(emu, pe.entryPoint, pe.imageBase);
+  }
+
+  return pe.imageBase;
+}
+
+function loadDll(emu: Emulator, rawName: string): number | undefined {
   // Normalize: strip path, lowercase, ensure .dll extension
   let basename = rawName.replace(/^.*[\\/]/, '').toLowerCase();
   if (!basename.includes('.')) basename += '.dll';
@@ -130,8 +236,43 @@ function loadDll(emu: Emulator, rawName: string): number {
     const key = fname.replace(/.*[/\\]/, '').toLowerCase();
     if (key === basename) { ab = data; break; }
   }
+
+  // If not in additionalFiles, search PATH directories via FileManager
   if (!ab) {
-    console.log(`[LoadLibrary] "${rawName}" not found in additionalFiles`);
+    const pathResult = findDllInPath(emu, basename);
+    if (pathResult && 'pending' in (pathResult as object)) {
+      // Async path: file is in IndexedDB, needs async fetch
+      const info = pathResult as PathSearchPending;
+      const stackBytes = emu._currentThunkStackBytes;
+      emu.waitingForMessage = true;
+      const capturedRawName = rawName;
+      const capturedBasename = basename;
+      emu.fs.fetchFileData(info.fileInfo, emu.additionalFiles, info.fullPath).then(buf => {
+        emu.waitingForMessage = false;
+        if (buf) {
+          // Cache for future lookups
+          const dfm = emu.fs as { virtualFileCache?: Map<string, ArrayBuffer> };
+          dfm.virtualFileCache?.set(info.fileInfo.name.toUpperCase(), buf);
+          try {
+            const base = loadDllFromBuffer(emu, buf, capturedRawName, capturedBasename);
+            emuCompleteThunk(emu, base, stackBytes);
+          } catch (e: unknown) {
+            console.log(`[LoadLibrary] Failed to load "${capturedRawName}": ${e instanceof Error ? e.message : String(e)}`);
+            emuCompleteThunk(emu, 0, stackBytes);
+          }
+        } else {
+          emuCompleteThunk(emu, 0, stackBytes);
+        }
+        if (emu.running && !emu.halted) {
+          requestAnimationFrame(emu.tick);
+        }
+      });
+      return undefined; // signals async in progress
+    }
+    ab = pathResult as ArrayBuffer | undefined;
+  }
+
+  if (!ab) {
     if (!hasRegisteredApis(emu, basename)) {
       // Truly missing DLL — notify user
       if (!emu.missingDlls.includes(basename)) {
@@ -146,52 +287,7 @@ function loadDll(emu: Emulator, rawName: string): number {
   }
 
   try {
-    // Detect address conflicts before loading
-    const { imageBase: preferred, sizeOfImage: dllSize } = parsePEHeader(ab);
-    const occupiedRanges: { base: number; size: number }[] = [];
-    occupiedRanges.push({ base: emu.pe.imageBase, size: emu.pe.sizeOfImage });
-    for (const [, mod] of emu.loadedModules) {
-      occupiedRanges.push({ base: mod.base, size: mod.sizeOfImage ?? 0x100000 });
-    }
-    let actualBase = preferred;
-    for (const r of occupiedRanges) {
-      if (actualBase < r.base + r.size && actualBase + dllSize > r.base) {
-        actualBase = ((r.base + r.size + 0xFFFF) & ~0xFFFF) >>> 0;
-      }
-    }
-    const baseOverride = actualBase !== preferred ? actualBase : undefined;
-
-    // Load DLL PE into emulator memory
-    const pe = loadPE(ab, emu.memory, baseOverride);
-
-    // Build thunks for the DLL's own imports (it imports from kernel32, user32, etc.)
-    const savedPe = emu.pe;
-    emu.pe = pe;
-    buildThunkTable(emu);
-    emu.pe = savedPe;
-    rebuildThunkPages(emu);
-
-    // Extract export table
-    const peInfo = parsePE(ab);
-    const exportResult = extractExports(peInfo, ab);
-    const exportFuncs = exportResult?.functions ?? [];
-
-    emu.loadedDllExports.set(basename, { base: pe.imageBase, exports: exportFuncs });
-    emu.loadedModules.set(basename, { base: pe.imageBase, resourceRva: pe.resourceRva, imageBase: pe.imageBase, sizeOfImage: pe.sizeOfImage });
-
-    console.log(`[LoadLibrary] Loaded "${rawName}" at 0x${pe.imageBase.toString(16)}, ${exportFuncs.length} exports`);
-
-    // Resolve transitive dependencies: load DLLs imported by this DLL from additionalFiles
-    if (emu.additionalFiles.size > 0) {
-      resolveSubDllImports(emu, pe);
-    }
-
-    // Call DllMain(DLL_PROCESS_ATTACH) for the loaded DLL
-    if (pe.entryPoint && pe.entryPoint !== pe.imageBase) {
-      emuCallDllMain(emu, pe.entryPoint, pe.imageBase);
-    }
-
-    return pe.imageBase;
+    return loadDllFromBuffer(emu, ab, rawName, basename);
   } catch (e: unknown) {
     console.log(`[LoadLibrary] Failed to load "${rawName}": ${e instanceof Error ? e.message : String(e)}`);
     return 0;


### PR DESCRIPTION
###  Summary

  - When an executable tries to load a DLL that isn't in its own directory, the emulator now searches PATH directories (D:\DOS, D:\WINDOWS, D:\WINDOWS\SYSTEM,
  D:\WINDOWS\SYSTEM32, etc.) via the FileManager
  - Works for both Win16 NE executables (import-time loading) and Win32 PE executables (LoadLibrary runtime loading)
  - Supports async fetch from IndexedDB for files stored in the virtual filesystem

###  Changes

  - emulator.ts: Extended default PATH with D:\WINDOWS\SYSTEM;C:\WINDOWS\SYSTEM
  - emu-load.ts: New findNEDllInPath() searches PATH for NE DLLs via fs.findFile() + fs.fetchFileData(). emuLoad/loadNEDlls are now async
  - kernel32/module.ts: New findDllInPath() for Win32 LoadLibrary PATH search with async IndexedDB support via emuCompleteThunk
  - EmulatorView.tsx: FileManager setup and virtualFiles population moved before emu.load() so PATH search has access to IndexedDB during NE DLL loading

###  Test plan

  - Launch WINFILE.EXE from desktop root — DLLs (VER, SCONFIG, COMMCTRL) found in D:\WINDOWS\SYSTEM via PATH
  - Launch WINFILE.EXE from within WINDOWS folder — still works (DLLs found in additionalFiles)
  - Launch a Win32 PE exe that uses LoadLibrary for a DLL in a PATH directory
  - Verify no regression on PE/MZ executables that don't need PATH search
