### PR TITLE
Await async emu.load() in all test harnesses

### DIFF
--- a/tests/test-notepad-cmdline-open.mjs
+++ b/tests/test-notepad-cmdline-open.mjs
@@ -64,7 +64,7 @@ emu.screenHeight = 600;
 emu.commandLine = 'D:\\TEST.TXT';
 emu.additionalFiles.set('TEST.TXT', testData.buffer);
 
-emu.load(realArrayBuffer, peInfo, mockCanvas);
+await emu.load(realArrayBuffer, peInfo, mockCanvas);
 emu.run();
 
 // Tick until message loop

--- a/tests/test-notepad-open.mjs
+++ b/tests/test-notepad-open.mjs
@@ -58,7 +58,7 @@ const peInfo = parsePE(realArrayBuffer);
 const emu = new Emulator();
 emu.screenWidth = 800;
 emu.screenHeight = 600;
-emu.load(realArrayBuffer, peInfo, mockCanvas);
+await emu.load(realArrayBuffer, peInfo, mockCanvas);
 
 // Enable API tracing
 emu.traceApi = true;

--- a/tests/test-notepad2003.mjs
+++ b/tests/test-notepad2003.mjs
@@ -55,7 +55,7 @@ const extractedMenus = extractMenus(peInfo, realArrayBuffer);
 const emu = new Emulator();
 emu.screenWidth = 800;
 emu.screenHeight = 600;
-emu.load(realArrayBuffer, peInfo, mockCanvas);
+await emu.load(realArrayBuffer, peInfo, mockCanvas);
 if (extractedMenus.length > 0) emu.menuItems = extractedMenus[0].menu.items;
 emu.run();
 

--- a/tests/test-pop.mjs
+++ b/tests/test-pop.mjs
@@ -20,7 +20,7 @@ const princeBuf = readToArrayBuffer('C:/Users/Olivier/Documents/0_Perso/dosbox_d
 const emu = new Emulator();
 emu.screenWidth = 320; emu.screenHeight = 200;
 emu.exeName = 'POP1DEMO/PRINCE.EXE'; emu.exePath = 'D:\\POP1DEMO\\PRINCE.EXE';
-emu.load(princeBuf, parsePE(princeBuf), mockCanvas);
+await emu.load(princeBuf, parsePE(princeBuf), mockCanvas);
 emu.run();
 
 for (let i = 0; i < 5000; i++) {

--- a/tests/test-secondreality.mjs
+++ b/tests/test-secondreality.mjs
@@ -67,7 +67,7 @@ emu.exePath = 'D:\\2nd_real\\SECOND.EXE';
 // REALITY.FC must be findable by file_int's fallback to dosOpenFile
 emu.additionalFiles.set('REALITY.FC', realityBuf);
 
-emu.load(secondBuf, peInfo, mockCanvas);
+await emu.load(secondBuf, peInfo, mockCanvas);
 emu.run();
 
 // Helper: dump MCB chain

--- a/tests/test-sr-crash.mjs
+++ b/tests/test-sr-crash.mjs
@@ -20,7 +20,7 @@ const emu = new Emulator();
 emu.screenWidth = 320; emu.screenHeight = 200;
 emu.exeName = '2nd_real/SECOND.EXE'; emu.exePath = 'D:\\2nd_real\\SECOND.EXE';
 emu.additionalFiles.set('REALITY.FC', realityBuf);
-emu.load(secondBuf, parsePE(secondBuf), mockCanvas);
+await emu.load(secondBuf, parsePE(secondBuf), mockCanvas);
 emu.run();
 for (let t = 0; t < 500; t++) { if (emu.halted) break; emu.tick(); if (emu._dosWaitingForKey) { emu.dosKeyBuffer.push({ ascii: 0x0D, scan: 0x1C }); break; } }
 

--- a/tests/test-winfile-crash.mjs
+++ b/tests/test-winfile-crash.mjs
@@ -60,7 +60,7 @@ emu.screenHeight = 600;
 emu.additionalFiles.set('COMMCTRL.DLL', readToArrayBuffer('H:/WINDOWS/SYSTEM/COMMCTRL.DLL'));
 emu.additionalFiles.set('VER.DLL', readToArrayBuffer('H:/WINDOWS/SYSTEM/VER.DLL'));
 emu.additionalFiles.set('SCONFIG.DLL', readToArrayBuffer('H:/WINDOWS/SYSTEM/SCONFIG.DLL'));
-emu.load(realArrayBuffer, peInfo, mockCanvas);
+await emu.load(realArrayBuffer, peInfo, mockCanvas);
 emu.run();
 
 let ticks = 0;

--- a/tests/test-winfile.mjs
+++ b/tests/test-winfile.mjs
@@ -63,7 +63,7 @@ emu.screenHeight = 600;
 emu.additionalFiles.set('COMMCTRL.DLL', readToArrayBuffer('H:/WINDOWS/SYSTEM/COMMCTRL.DLL'));
 emu.additionalFiles.set('VER.DLL', readToArrayBuffer('H:/WINDOWS/SYSTEM/VER.DLL'));
 emu.additionalFiles.set('SCONFIG.DLL', readToArrayBuffer('H:/WINDOWS/SYSTEM/SCONFIG.DLL'));
-emu.load(realArrayBuffer, peInfo, mockCanvas);
+await emu.load(realArrayBuffer, peInfo, mockCanvas);
 emu.run();
 
 // Tick until message loop reached


### PR DESCRIPTION
### Summary

  - emu.load() was made async in #31 but the test files were not updated to await the call
  - Fixed all 8 test harnesses: test-pop, test-secondreality, test-sr-crash, test-winfile, test-winfile-crash,
  test-notepad-cmdline-open, test-notepad-open, test-notepad2003
