### PR TITLE
 Add DOS speed control and VGA refresh rate settings

### DIFF
--- a/src/components/DosSettingsWindow.tsx
+++ b/src/components/DosSettingsWindow.tsx
@@ -14,8 +14,12 @@ const radioStyle: Record<string, string | number> = {
 const SPEED_OPTIONS = [
   { value: 1, label: '1x' },
   { value: 0.75, label: '0.75x' },
+  { value: 0.65, label: '0.65x' },
   { value: 0.5, label: '0.5x' },
+  { value: 0.35, label: '0.35x' },
   { value: 0.25, label: '0.25x' },
+  { value: 0.15, label: '0.15x' },
+  { value: 0.1, label: '0.1x' },
 ];
 
 interface DosSettingsWindowProps {

--- a/src/components/DosSettingsWindow.tsx
+++ b/src/components/DosSettingsWindow.tsx
@@ -11,6 +11,13 @@ const radioStyle: Record<string, string | number> = {
   marginBottom: '4px',
 };
 
+const SPEED_OPTIONS = [
+  { value: 1, label: '1x' },
+  { value: 0.75, label: '0.75x' },
+  { value: 0.5, label: '0.5x' },
+  { value: 0.25, label: '0.25x' },
+];
+
 interface DosSettingsWindowProps {
   onClose: () => void;
   onFocus: () => void;
@@ -63,6 +70,20 @@ export function DosSettingsWindow({ onClose, onFocus, onMinimize, zIndex, focuse
                 />
                 {t().textRendererCanvas}
               </label>
+            </div>
+
+            {/* Speed */}
+            <div style={{ marginBottom: '10px' }}>
+              <div style={{ font: FONT, marginBottom: '6px', fontWeight: 'bold' }}>{t().labelSpeed}</div>
+              <select
+                style={{ font: FONT, width: '100px', background: '#FFF' }}
+                value={settings.speed}
+                onChange={(e) => setSettings(s => ({ ...s, speed: Number((e.target as HTMLSelectElement).value) }))}
+              >
+                {SPEED_OPTIONS.map(opt => (
+                  <option key={opt.value} value={opt.value}>{opt.label}</option>
+                ))}
+              </select>
             </div>
 
             {/* JIT compiler */}

--- a/src/components/DosSettingsWindow.tsx
+++ b/src/components/DosSettingsWindow.tsx
@@ -11,6 +11,8 @@ const radioStyle: Record<string, string | number> = {
   marginBottom: '4px',
 };
 
+const REFRESH_OPTIONS = [30, 45, 60, 70, 100];
+
 const SPEED_OPTIONS = [
   { value: 1, label: '1x' },
   { value: 0.75, label: '0.75x' },
@@ -86,6 +88,20 @@ export function DosSettingsWindow({ onClose, onFocus, onMinimize, zIndex, focuse
               >
                 {SPEED_OPTIONS.map(opt => (
                   <option key={opt.value} value={opt.value}>{opt.label}</option>
+                ))}
+              </select>
+            </div>
+
+            {/* Refresh rate */}
+            <div style={{ marginBottom: '10px' }}>
+              <div style={{ font: FONT, marginBottom: '6px', fontWeight: 'bold' }}>{t().labelRefreshRate}</div>
+              <select
+                style={{ font: FONT, width: '100px', background: '#FFF' }}
+                value={settings.refreshRate}
+                onChange={(e) => setSettings(s => ({ ...s, refreshRate: Number((e.target as HTMLSelectElement).value) }))}
+              >
+                {REFRESH_OPTIONS.map(hz => (
+                  <option key={hz} value={hz}>{hz} Hz</option>
                 ))}
               </select>
             </div>

--- a/src/components/EmulatorView.tsx
+++ b/src/components/EmulatorView.tsx
@@ -695,6 +695,7 @@ export function EmulatorView({ arrayBuffer, peInfo, additionalFiles, exeName, co
           const ds = loadDosSettings();
           childEmu.wasmJitEnabled = ds.jitEnabled;
           childEmu.dosSpeedFactor = ds.speed;
+          childEmu.vga.refreshHz = ds.refreshRate;
         }
 
         // Share console state AFTER load() so initConsoleBuffer doesn't overwrite
@@ -759,6 +760,7 @@ export function EmulatorView({ arrayBuffer, peInfo, additionalFiles, exeName, co
           const ds = loadDosSettings();
           emu.wasmJitEnabled = ds.jitEnabled;
           emu.dosSpeedFactor = ds.speed;
+          emu.vga.refreshHz = ds.refreshRate;
         }
 
         // Assign shared AudioContext — created in App during user gesture
@@ -818,6 +820,8 @@ export function EmulatorView({ arrayBuffer, peInfo, additionalFiles, exeName, co
       const ds = loadDosSettings();
       emu.wasmJitEnabled = ds.jitEnabled;
       emu.dosSpeedFactor = ds.speed;
+      emu.vga.refreshHz = ds.refreshRate;
+      emu.vga.invalidateRetraceCache();
     };
     window.addEventListener('retrotick-settings-changed', onSettingsChanged);
     return () => window.removeEventListener('retrotick-settings-changed', onSettingsChanged);

--- a/src/components/EmulatorView.tsx
+++ b/src/components/EmulatorView.tsx
@@ -691,7 +691,11 @@ export function EmulatorView({ arrayBuffer, peInfo, additionalFiles, exeName, co
 
         // Load child (this creates its own consoleBuffer via initConsoleBuffer)
         await childEmu.load(childData, childPeInfo, canvas);
-        if (childEmu.isDOS) childEmu.wasmJitEnabled = loadDosSettings().jitEnabled;
+        if (childEmu.isDOS) {
+          const ds = loadDosSettings();
+          childEmu.wasmJitEnabled = ds.jitEnabled;
+          childEmu.dosSpeedFactor = ds.speed;
+        }
 
         // Share console state AFTER load() so initConsoleBuffer doesn't overwrite
         childEmu.consoleBuffer = emu.consoleBuffer;
@@ -750,8 +754,12 @@ export function EmulatorView({ arrayBuffer, peInfo, additionalFiles, exeName, co
 
       // Load registry from IndexedDB then start
       initAndRun().then(() => {
-        // Enable WASM JIT if configured in DOS Settings
-        if (emu.isDOS) emu.wasmJitEnabled = loadDosSettings().jitEnabled;
+        // Apply DOS Settings
+        if (emu.isDOS) {
+          const ds = loadDosSettings();
+          emu.wasmJitEnabled = ds.jitEnabled;
+          emu.dosSpeedFactor = ds.speed;
+        }
 
         // Assign shared AudioContext — created in App during user gesture
         if (sharedAudioContext) {
@@ -801,6 +809,19 @@ export function EmulatorView({ arrayBuffer, peInfo, additionalFiles, exeName, co
       if (iconUrl) URL.revokeObjectURL(iconUrl);
     };
   }, [arrayBuffer, peInfo, resetCount]);
+
+  // Live-update DOS settings (speed, JIT) without restarting
+  useEffect(() => {
+    const onSettingsChanged = () => {
+      const emu = emuRef.current;
+      if (!emu || !emu.isDOS) return;
+      const ds = loadDosSettings();
+      emu.wasmJitEnabled = ds.jitEnabled;
+      emu.dosSpeedFactor = ds.speed;
+    };
+    window.addEventListener('retrotick-settings-changed', onSettingsChanged);
+    return () => window.removeEventListener('retrotick-settings-changed', onSettingsChanged);
+  }, []);
 
   // File open/save dialogs are now rendered as FileDialog components (see JSX below)
 

--- a/src/lib/dos-settings.ts
+++ b/src/lib/dos-settings.ts
@@ -6,6 +6,8 @@ export interface DosSettings {
   textRenderer: 'dom' | 'canvas';
   /** Enable experimental WASM JIT compiler for DOS programs. */
   jitEnabled: boolean;
+  /** CPU speed factor: 1 = full speed, 0.5 = half speed, etc. */
+  speed: number;
 }
 
 const STORAGE_KEY = 'retrotick-dos';
@@ -13,6 +15,7 @@ const STORAGE_KEY = 'retrotick-dos';
 const DEFAULTS: DosSettings = {
   textRenderer: 'dom',
   jitEnabled: false,
+  speed: 1,
 };
 
 export function loadDosSettings(): DosSettings {

--- a/src/lib/dos-settings.ts
+++ b/src/lib/dos-settings.ts
@@ -8,6 +8,8 @@ export interface DosSettings {
   jitEnabled: boolean;
   /** CPU speed factor: 1 = full speed, 0.5 = half speed, etc. */
   speed: number;
+  /** VGA refresh rate in Hz (standard CRT = 70). */
+  refreshRate: number;
 }
 
 const STORAGE_KEY = 'retrotick-dos';
@@ -16,6 +18,7 @@ const DEFAULTS: DosSettings = {
   textRenderer: 'dom',
   jitEnabled: false,
   speed: 1,
+  refreshRate: 70,
 };
 
 export function loadDosSettings(): DosSettings {

--- a/src/lib/emu/dos/keyboard.ts
+++ b/src/lib/emu/dos/keyboard.ts
@@ -174,7 +174,7 @@ export function handleInt09(cpu: CPU, emu: Emulator, scancodeOverride?: number):
   }
 
   // Cap software key buffer to prevent overflow from key repeat
-  if (emu.dosKeyBuffer.length < 32) {
+  if (emu.dosKeyBuffer.length < 16) {
     emu.dosKeyBuffer.push({ ascii, scan: scancode });
   }
   emu.writeBdaKey(ascii, scancode);

--- a/src/lib/emu/dos/vga.ts
+++ b/src/lib/emu/dos/vga.ts
@@ -2,8 +2,8 @@
 
 import type { Emulator } from '../emulator';
 
-/** VGA refresh rate in Hz (standard CRT = 70). Increase to speed up frame-locked demos. */
-export const VGA_REFRESH_HZ = 70;
+/** Default VGA refresh rate in Hz (standard CRT = 70). */
+export const VGA_REFRESH_HZ_DEFAULT = 70;
 
 export interface VGAMode {
   mode: number;
@@ -135,6 +135,7 @@ export class VGAState {
   dirty = false;
 
   // VGA retrace timing
+  refreshHz = VGA_REFRESH_HZ_DEFAULT; // configurable refresh rate
   private lastVblankSync = false;  // was previous 0x3DA read in VBlank?
   pendingSync = false;             // set when VBlank starts; tick should sync & present
   lastSyncTime = 0;                // performance.now() of last syncGraphics call
@@ -149,6 +150,9 @@ export class VGAState {
   private _retraceConstsDirty = true;
   private _cached3DA = 0;          // cached 0x3DA result (recomputed every 64 polls)
 
+  /** Invalidate retrace cache so next 0x3DA read picks up new refreshHz */
+  invalidateRetraceCache(): void { this._retraceConstsDirty = true; }
+
   /** Refresh retrace constants when CRTC regs change */
   private _updateRetraceConsts(): void {
     // Use raw VDE+1 (actual scanlines on CRT) for retrace timing, NOT getVisibleHeight()
@@ -158,7 +162,7 @@ export class VGAState {
     const overflow = this.crtcRegs[0x07];
     const visibleScanlines = (vdeLow | ((overflow & 0x02) ? 0x100 : 0) | ((overflow & 0x40) ? 0x200 : 0)) + 1;
     const nativeTotalLines = (visibleScanlines <= 400) ? 449 : 525;
-    const totalLines = Math.round((1000000 / VGA_REFRESH_HZ) / 31.778);
+    const totalLines = Math.round((1000000 / this.refreshHz) / 31.778);
     this._cachedVisibleLines = Math.round(totalLines * visibleScanlines / nativeTotalLines);
     this._cachedFrameUs = totalLines * 31.778;
     this._retraceConstsDirty = false;

--- a/src/lib/emu/emu-exec.ts
+++ b/src/lib/emu/emu-exec.ts
@@ -599,7 +599,7 @@ export function emuTick(emu: Emulator): void {
 
   const tickStart = performance.now();
   let stepCount = 0;
-  const tickMs = emu.isDOS ? DOS_TICK_MS : 50;
+  const tickMs = emu.isDOS ? DOS_TICK_MS * emu.dosSpeedFactor : 50;
   let dosYieldAfterKeyAt = -1;
   let prevDosKeyBufferLen = emu.dosKeyBuffer.length;
   let prevBdaKeyHead = emu.isDOS ? emu.memory.readU16(0x41A) : 0;
@@ -699,10 +699,13 @@ export function emuTick(emu: Emulator): void {
       }
     }
     if (emu.halted || emu.waitingForMessage || emu._dosHalted) break;
-    if (emu.isDOS && dosYieldAfterKeyAt < 0 && (emu._dosKeyConsumedThisTick || emu._dosHwKeyReadThisTick)) {
+    if (emu.isDOS && dosYieldAfterKeyAt < 0 && emu.dosSpeedFactor >= 1
+        && (emu._dosKeyConsumedThisTick || emu._dosHwKeyReadThisTick)) {
       // A DOS key was consumed this tick (INT 16h or direct port 0x60 path):
       // let guest run a little longer
       // so it can finish drawing before we yield/sync the frame.
+      // Disabled at reduced speed: rAF + reduced tickMs already ensures 60Hz sync,
+      // and yielding after 128 insns would starve the game (~7k insns/sec).
       dosYieldAfterKeyAt = i + DOS_POST_KEY_STEPS;
     }
     if (dosYieldAfterKeyAt >= 0 && i >= dosYieldAfterKeyAt) break;
@@ -769,9 +772,12 @@ export function emuTick(emu: Emulator): void {
         else if (code === 0xB8) emu.memory.writeU8(BDA_SHIFT, flags & ~0x08); // Alt break
         emu._pendingHwInts.push(0x09);
         if (code !== 0xE0) emu._lastHwKeyDeliverTime = now;
-        if (emu.isDOS && dosYieldAfterKeyAt < 0 && code !== 0xE0) {
+        if (emu.isDOS && dosYieldAfterKeyAt < 0 && code !== 0xE0
+            && emu._pendingHwKeys.length === 0) {
           // Hardware key delivered this tick: give DOS app a short execution window
           // to finish drawing, then yield/sync so the frame is observable.
+          // Skip when more keys are queued (key repeat) — no point yielding just
+          // to deliver another key next tick; that starves the game at low speed.
           dosYieldAfterKeyAt = i + DOS_POST_KEY_STEPS;
         }
         emu._hwKeyDelay = 0;
@@ -1238,10 +1244,9 @@ export function emuTick(emu: Emulator): void {
       // DOS games need maximum throughput — MessageChannel avoids setTimeout's
       // 4ms clamping after 5 nested calls, giving near-zero inter-tick delay.
       if (emu.dosSpeedFactor < 1) {
-        // Throttle: run 16ms of instructions, then idle proportionally.
-        // delay = 16 * (1/speed - 1)  →  0.5x = 16ms, 0.25x = 48ms
-        const delay = DOS_TICK_MS * (1 / emu.dosSpeedFactor - 1);
-        setTimeout(emu.tick, delay);
+        // Frame-locked throttling: reduced tick budget (tickMs = 16 * speed)
+        // fills only part of each ~16.7ms rAF frame → smooth, predictable slowdown.
+        requestAnimationFrame(emu.tick);
       } else {
         scheduleImmediate(emu.tick);
       }

--- a/src/lib/emu/emu-exec.ts
+++ b/src/lib/emu/emu-exec.ts
@@ -554,6 +554,7 @@ export function emuCallNative(emu: Emulator, addr: number): number | undefined {
 }
 
 const BATCH_SIZE = 500000;
+const DOS_TICK_MS = 16; // fill one rAF frame (~16.7ms) for maximum throughput
 const DOS_POST_KEY_STEPS = 0x80;
 
 // WASM JIT diagnostics — logs every ~1s
@@ -598,7 +599,6 @@ export function emuTick(emu: Emulator): void {
 
   const tickStart = performance.now();
   let stepCount = 0;
-  const DOS_TICK_MS = 16; // fill one rAF frame (~16.7ms) for maximum throughput
   const tickMs = emu.isDOS ? DOS_TICK_MS : 50;
   let dosYieldAfterKeyAt = -1;
   let prevDosKeyBufferLen = emu.dosKeyBuffer.length;
@@ -1237,7 +1237,14 @@ export function emuTick(emu: Emulator): void {
     } else if (emu.isDOS) {
       // DOS games need maximum throughput — MessageChannel avoids setTimeout's
       // 4ms clamping after 5 nested calls, giving near-zero inter-tick delay.
-      scheduleImmediate(emu.tick);
+      if (emu.dosSpeedFactor < 1) {
+        // Throttle: run 16ms of instructions, then idle proportionally.
+        // delay = 16 * (1/speed - 1)  →  0.5x = 16ms, 0.25x = 48ms
+        const delay = DOS_TICK_MS * (1 / emu.dosSpeedFactor - 1);
+        setTimeout(emu.tick, delay);
+      } else {
+        scheduleImmediate(emu.tick);
+      }
     } else {
       requestAnimationFrame(emu.tick);
     }

--- a/src/lib/emu/emulator.ts
+++ b/src/lib/emu/emulator.ts
@@ -1738,7 +1738,9 @@ export class Emulator {
           ];
           const isExtended = this._injectE0Pending || scancode >= 0x3B;
           const ascii = isExtended ? 0 : (browserChar ?? SCAN_TO_ASCII[scancode] ?? 0);
-          this.dosKeyBuffer.push({ ascii, scan: scancode });
+          if (this.dosKeyBuffer.length < 16) {
+            this.dosKeyBuffer.push({ ascii, scan: scancode });
+          }
           this._injectE0Pending = false;
         }
       }

--- a/src/lib/emu/emulator.ts
+++ b/src/lib/emu/emulator.ts
@@ -436,6 +436,7 @@ export class Emulator {
 
   // WASM JIT (DOS programs only)
   wasmJitEnabled = false; // set to true to enable WASM JIT for DOS programs
+  dosSpeedFactor = 1; // 1 = full speed, 0.5 = half, 0.25 = quarter
   flatMemory: FlatMemory | null = null;  // created lazily for DOS programs
   wasmRegions = new Map<number, WasmCompiledRegion>();  // EIP-base → compiled region
   _wasmPending = new Set<number>();  // addresses with pending compilations

--- a/src/lib/ui-strings.ts
+++ b/src/lib/ui-strings.ts
@@ -81,6 +81,7 @@ export interface UiStrings {
   labelTextRenderer: string;
   textRendererDom: string;
   textRendererCanvas: string;
+  labelSpeed: string;
   labelJit: string;
   jitExperimental: string;
   // Properties dialog
@@ -200,6 +201,7 @@ const en: UiStrings = {
   labelTextRenderer: 'Text rendering',
   textRendererDom: 'DOM (text selectable)',
   textRendererCanvas: 'Canvas (precise, no text selection)',
+  labelSpeed: 'Speed',
   labelJit: 'WASM JIT Compiler',
   jitExperimental: 'Enable (experimental)',
   properties: 'Properties',
@@ -308,6 +310,7 @@ const fr: UiStrings = {
   labelTextRenderer: 'Rendu texte',
   textRendererDom: 'DOM (texte s\u00e9lectionnable)',
   textRendererCanvas: 'Canvas (pr\u00e9cis, pas de s\u00e9lection de texte)',
+  labelSpeed: 'Vitesse',
   labelJit: 'Compilateur WASM JIT',
   jitExperimental: 'Activer (exp\u00e9rimental)',
   properties: 'Propri\u00e9t\u00e9s',
@@ -416,6 +419,7 @@ const de: UiStrings = {
   labelTextRenderer: 'Textdarstellung',
   textRendererDom: 'DOM (Text ausw\u00e4hlbar)',
   textRendererCanvas: 'Canvas (pr\u00e4zise, kein Text ausw\u00e4hlbar)',
+  labelSpeed: 'Geschwindigkeit',
   labelJit: 'WASM-JIT-Compiler',
   jitExperimental: 'Aktivieren (experimentell)',
   properties: 'Eigenschaften',
@@ -524,6 +528,7 @@ const es: UiStrings = {
   labelTextRenderer: 'Renderizado de texto',
   textRendererDom: 'DOM (texto seleccionable)',
   textRendererCanvas: 'Canvas (preciso, sin selecci\u00f3n de texto)',
+  labelSpeed: 'Velocidad',
   labelJit: 'Compilador WASM JIT',
   jitExperimental: 'Activar (experimental)',
   properties: 'Propiedades',
@@ -632,6 +637,7 @@ const ja: UiStrings = {
   labelTextRenderer: '\u30c6\u30ad\u30b9\u30c8\u63cf\u753b',
   textRendererDom: 'DOM (\u30c6\u30ad\u30b9\u30c8\u9078\u629e\u53ef)',
   textRendererCanvas: 'Canvas (\u6b63\u78ba\u3001\u30c6\u30ad\u30b9\u30c8\u9078\u629e\u4e0d\u53ef)',
+  labelSpeed: '\u901f\u5ea6',
   labelJit: 'WASM JIT \u30b3\u30f3\u30d1\u30a4\u30e9',
   jitExperimental: '\u6709\u52b9\u306b\u3059\u308b\uff08\u5b9f\u9a13\u7684\uff09',
   properties: '\u30d7\u30ed\u30d1\u30c6\u30a3',
@@ -740,6 +746,7 @@ const zhCN: UiStrings = {
   labelTextRenderer: '\u6587\u672c\u6e32\u67d3',
   textRendererDom: 'DOM (\u53ef\u9009\u62e9\u6587\u672c)',
   textRendererCanvas: 'Canvas (\u7cbe\u786e\uff0c\u4e0d\u53ef\u9009\u62e9\u6587\u672c)',
+  labelSpeed: '\u901f\u5ea6',
   labelJit: 'WASM JIT \u7f16\u8bd1\u5668',
   jitExperimental: '\u542f\u7528\uff08\u5b9e\u9a8c\u6027\uff09',
   properties: '\u5c5e\u6027',
@@ -848,6 +855,7 @@ const ptBR: UiStrings = {
   labelTextRenderer: 'Renderiza\u00e7\u00e3o de texto',
   textRendererDom: 'DOM (texto selecion\u00e1vel)',
   textRendererCanvas: 'Canvas (preciso, sem sele\u00e7\u00e3o de texto)',
+  labelSpeed: 'Velocidade',
   labelJit: 'Compilador WASM JIT',
   jitExperimental: 'Ativar (experimental)',
   properties: 'Propriedades',
@@ -956,6 +964,7 @@ const it: UiStrings = {
   labelTextRenderer: 'Rendering testo',
   textRendererDom: 'DOM (testo selezionabile)',
   textRendererCanvas: 'Canvas (preciso, senza selezione testo)',
+  labelSpeed: 'Velocit\u00e0',
   labelJit: 'Compilatore WASM JIT',
   jitExperimental: 'Attivare (sperimentale)',
   properties: 'Propriet\u00e0',
@@ -1064,6 +1073,7 @@ const pl: UiStrings = {
   labelTextRenderer: 'Renderowanie tekstu',
   textRendererDom: 'DOM (tekst do zaznaczenia)',
   textRendererCanvas: 'Canvas (dok\u0142adny, bez zaznaczania tekstu)',
+  labelSpeed: 'Pr\u0119dko\u015b\u0107',
   labelJit: 'Kompilator WASM JIT',
   jitExperimental: 'W\u0142\u0105cz (eksperymentalny)',
   properties: 'W\u0142a\u015bciwo\u015bci',
@@ -1172,6 +1182,7 @@ const ko: UiStrings = {
   labelTextRenderer: '\ud14d\uc2a4\ud2b8 \ub80c\ub354\ub9c1',
   textRendererDom: 'DOM (\ud14d\uc2a4\ud2b8 \uc120\ud0dd \uac00\ub2a5)',
   textRendererCanvas: 'Canvas (\uc815\ubc00, \ud14d\uc2a4\ud2b8 \uc120\ud0dd \ubd88\uac00)',
+  labelSpeed: '\uc18d\ub3c4',
   labelJit: 'WASM JIT \ucef4\ud30c\uc77c\ub7ec',
   jitExperimental: '\ud65c\uc131\ud654 (\uc2e4\ud5d8\uc801)',
   properties: '\uc18d\uc131',

--- a/src/lib/ui-strings.ts
+++ b/src/lib/ui-strings.ts
@@ -82,6 +82,7 @@ export interface UiStrings {
   textRendererDom: string;
   textRendererCanvas: string;
   labelSpeed: string;
+  labelRefreshRate: string;
   labelJit: string;
   jitExperimental: string;
   // Properties dialog
@@ -202,6 +203,7 @@ const en: UiStrings = {
   textRendererDom: 'DOM (text selectable)',
   textRendererCanvas: 'Canvas (precise, no text selection)',
   labelSpeed: 'Speed',
+  labelRefreshRate: 'Refresh rate',
   labelJit: 'WASM JIT Compiler',
   jitExperimental: 'Enable (experimental)',
   properties: 'Properties',
@@ -311,6 +313,7 @@ const fr: UiStrings = {
   textRendererDom: 'DOM (texte s\u00e9lectionnable)',
   textRendererCanvas: 'Canvas (pr\u00e9cis, pas de s\u00e9lection de texte)',
   labelSpeed: 'Vitesse',
+  labelRefreshRate: 'Fr\u00e9quence d\u2019affichage',
   labelJit: 'Compilateur WASM JIT',
   jitExperimental: 'Activer (exp\u00e9rimental)',
   properties: 'Propri\u00e9t\u00e9s',
@@ -420,6 +423,7 @@ const de: UiStrings = {
   textRendererDom: 'DOM (Text ausw\u00e4hlbar)',
   textRendererCanvas: 'Canvas (pr\u00e4zise, kein Text ausw\u00e4hlbar)',
   labelSpeed: 'Geschwindigkeit',
+  labelRefreshRate: 'Bildwiederholrate',
   labelJit: 'WASM-JIT-Compiler',
   jitExperimental: 'Aktivieren (experimentell)',
   properties: 'Eigenschaften',
@@ -529,6 +533,7 @@ const es: UiStrings = {
   textRendererDom: 'DOM (texto seleccionable)',
   textRendererCanvas: 'Canvas (preciso, sin selecci\u00f3n de texto)',
   labelSpeed: 'Velocidad',
+  labelRefreshRate: 'Frecuencia de actualizaci\u00f3n',
   labelJit: 'Compilador WASM JIT',
   jitExperimental: 'Activar (experimental)',
   properties: 'Propiedades',
@@ -638,6 +643,7 @@ const ja: UiStrings = {
   textRendererDom: 'DOM (\u30c6\u30ad\u30b9\u30c8\u9078\u629e\u53ef)',
   textRendererCanvas: 'Canvas (\u6b63\u78ba\u3001\u30c6\u30ad\u30b9\u30c8\u9078\u629e\u4e0d\u53ef)',
   labelSpeed: '\u901f\u5ea6',
+  labelRefreshRate: '\u30ea\u30d5\u30ec\u30c3\u30b7\u30e5\u30ec\u30fc\u30c8',
   labelJit: 'WASM JIT \u30b3\u30f3\u30d1\u30a4\u30e9',
   jitExperimental: '\u6709\u52b9\u306b\u3059\u308b\uff08\u5b9f\u9a13\u7684\uff09',
   properties: '\u30d7\u30ed\u30d1\u30c6\u30a3',
@@ -747,6 +753,7 @@ const zhCN: UiStrings = {
   textRendererDom: 'DOM (\u53ef\u9009\u62e9\u6587\u672c)',
   textRendererCanvas: 'Canvas (\u7cbe\u786e\uff0c\u4e0d\u53ef\u9009\u62e9\u6587\u672c)',
   labelSpeed: '\u901f\u5ea6',
+  labelRefreshRate: '\u5237\u65b0\u7387',
   labelJit: 'WASM JIT \u7f16\u8bd1\u5668',
   jitExperimental: '\u542f\u7528\uff08\u5b9e\u9a8c\u6027\uff09',
   properties: '\u5c5e\u6027',
@@ -856,6 +863,7 @@ const ptBR: UiStrings = {
   textRendererDom: 'DOM (texto selecion\u00e1vel)',
   textRendererCanvas: 'Canvas (preciso, sem sele\u00e7\u00e3o de texto)',
   labelSpeed: 'Velocidade',
+  labelRefreshRate: 'Taxa de atualiza\u00e7\u00e3o',
   labelJit: 'Compilador WASM JIT',
   jitExperimental: 'Ativar (experimental)',
   properties: 'Propriedades',
@@ -965,6 +973,7 @@ const it: UiStrings = {
   textRendererDom: 'DOM (testo selezionabile)',
   textRendererCanvas: 'Canvas (preciso, senza selezione testo)',
   labelSpeed: 'Velocit\u00e0',
+  labelRefreshRate: 'Frequenza di aggiornamento',
   labelJit: 'Compilatore WASM JIT',
   jitExperimental: 'Attivare (sperimentale)',
   properties: 'Propriet\u00e0',
@@ -1074,6 +1083,7 @@ const pl: UiStrings = {
   textRendererDom: 'DOM (tekst do zaznaczenia)',
   textRendererCanvas: 'Canvas (dok\u0142adny, bez zaznaczania tekstu)',
   labelSpeed: 'Pr\u0119dko\u015b\u0107',
+  labelRefreshRate: 'Cz\u0119stotliwo\u015b\u0107 od\u015bwie\u017cania',
   labelJit: 'Kompilator WASM JIT',
   jitExperimental: 'W\u0142\u0105cz (eksperymentalny)',
   properties: 'W\u0142a\u015bciwo\u015bci',
@@ -1183,6 +1193,7 @@ const ko: UiStrings = {
   textRendererDom: 'DOM (\ud14d\uc2a4\ud2b8 \uc120\ud0dd \uac00\ub2a5)',
   textRendererCanvas: 'Canvas (\uc815\ubc00, \ud14d\uc2a4\ud2b8 \uc120\ud0dd \ubd88\uac00)',
   labelSpeed: '\uc18d\ub3c4',
+  labelRefreshRate: '\uc8fc\uc0ac\uc728',
   labelJit: 'WASM JIT \ucef4\ud30c\uc77c\ub7ec',
   jitExperimental: '\ud65c\uc131\ud654 (\uc2e4\ud5d8\uc801)',
   properties: '\uc18d\uc131',


### PR DESCRIPTION
### Summary

  - Add a CPU speed setting (1x down to 0.1x) to slow down DOS games that run too fast (e.g. Moktar)
  - Add a VGA refresh rate setting (30/45/60/70/100 Hz) for games that sync on VBlank
  - Both settings apply in real-time without restarting the game

### Details

  - Speed throttling uses requestAnimationFrame with a reduced instruction budget per tick (tickMs = 16 * speed) instead
   of setTimeout delays, for smooth frame-locked slowdown
  - Keyboard buffer capped to 16 entries (real BIOS buffer size) to prevent accumulation at low speed
  - Yield-after-key optimization disabled at reduced speed to avoid starving the game to ~128 instructions per tick
  - VGA retrace timing (0x3DA port) derived from configurable refreshHz instead of hardcoded 70 Hz constant
  - All labels translated in 10 languages

### Test plan

  - Open DOS Settings, change speed to 0.5x, run a fast game (Moktar) — should be noticeably slower
  - Hold a key down at reduced speed — no severe lag
  - Change speed back to 1x — game runs at full speed immediately
  - Change refresh rate to 30 Hz, run a VBlank-synced game — should run slower
  - Change refresh rate to 100 Hz — VBlank-synced games run faster
  - Verify settings persist across page reload
