### PR TITLE
Fix Sound Blaster audio for DOS games

### DIFF
--- a/src/lib/emu/dos/audio.ts
+++ b/src/lib/emu/dos/audio.ts
@@ -235,8 +235,21 @@ if (!globalThis._oplRegistered) {
 
     if (port === 0x00) return this.dma.readAddr(0);
     if (port === 0x01) return this.dma.readCount(0);
-    if (port === 0x02) return this.dma.readAddr(1);
-    if (port === 0x03) return this.dma.readCount(1);
+    if (port === 0x02) {
+      // Sync DMA transfer before reading current address — zpollme uses this
+      // to determine where to write in the buffer. Without sync, the address
+      // is only updated every 512 instructions and zpollme sees stale values.
+      if (this.sbDsp.dmaActive) {
+        if (this.sbDsp.tickDMA(this.dma, this.readMemory)) this.onSBIRQ();
+      }
+      return this.dma.readAddr(1);
+    }
+    if (port === 0x03) {
+      if (this.sbDsp.dmaActive) {
+        if (this.sbDsp.tickDMA(this.dma, this.readMemory)) this.onSBIRQ();
+      }
+      return this.dma.readCount(1);
+    }
     if (port === 0x04) return this.dma.readAddr(2);
     if (port === 0x05) return this.dma.readCount(2);
     if (port === 0x06) return this.dma.readAddr(3);

--- a/src/lib/emu/dos/audio.ts
+++ b/src/lib/emu/dos/audio.ts
@@ -22,7 +22,7 @@ export { GUS } from './gus';
 export class DosAudio {
   private opl2: OPL2;
   private speaker: PCSpeaker;
-  private sbDsp: SoundBlasterDSP;
+  readonly sbDsp: SoundBlasterDSP;
   readonly dma = new DMAController();
   private ctx: AudioContext | null = null;
   private workletNode: AudioWorkletNode | null = null;

--- a/src/lib/emu/dos/audio.ts
+++ b/src/lib/emu/dos/audio.ts
@@ -266,6 +266,15 @@ if (!globalThis._oplRegistered) {
     // Sound Blaster DSP ports (base 0x220)
     if (port === 0x226) { this.sbDsp.writeReset(value); return true; }
     if (port === 0x22C) { this.sbDsp.writeCommand(value); return true; }
+    // SB Pro mixer ports
+    if (port === 0x224) { this.sbDsp.mixerAddr = value; return true; }
+    if (port === 0x225) {
+      if (this.sbDsp.mixerAddr === 0x0E) {
+        // Stereo/mono select: bit 1 = stereo, bit 5 = filter
+        this.sbDsp.stereoMode = !!(value & 0x02);
+      }
+      return true;
+    }
 
     // DMA controller ports (channels 0-3)
     if (port === 0x00) { this.dma.writeAddr(0, value); return true; }

--- a/src/lib/emu/dos/audio.ts
+++ b/src/lib/emu/dos/audio.ts
@@ -31,6 +31,8 @@ export class DosAudio {
   private sharedBuf: Float32Array | null = null;
   private writePos = 0;
   private fillTimer = 0;
+  /** Fill function reference — called from tick loop to prevent starvation. */
+  private fillFn: (() => void) | null = null;
   /** Callback to read a byte from emulator memory (set by emu-load). */
   readMemory: (addr: number) => number = () => 0;
   /** Callback to write a byte to emulator memory (set by emu-load). */
@@ -186,6 +188,7 @@ if (!globalThis._oplRegistered) {
           Atomics.store(pointers, 0, this.writePos);
           lastFillTime = now;
         };
+        this.fillFn = fill;
         this.fillTimer = setInterval(fill, FILL_INTERVAL_MS) as unknown as number;
       } else {
         // Fallback: periodically post samples via message port, with time tracking
@@ -207,6 +210,7 @@ if (!globalThis._oplRegistered) {
           });
           lastFillTime = now;
         };
+        this.fillFn = fill;
         this.fillTimer = setInterval(fill, FILL_INTERVAL_MS) as unknown as number;
       }
     }).catch(() => {
@@ -297,6 +301,12 @@ if (!globalThis._oplRegistered) {
   }
 
   /**
+   * Force audio sample generation. Call from the tick loop to ensure audio
+   * fills even when scheduleImmediate starves setInterval callbacks.
+   */
+  flushAudio(): void { this.fillFn?.(); }
+
+  /**
    * Advance DMA transfer and check OPL2 timers. Called from main tick loop.
    * Fires IRQ 7 (via onSBIRQ callback) when a transfer block completes
    * or an OPL2 timer expires.
@@ -319,12 +329,17 @@ if (!globalThis._oplRegistered) {
     const outRate = this.ctx?.sampleRate ?? 44100;
     const ratio = sbRate / outRate;
     for (let i = 0; i < length; i++) {
-      this.pcmAccum += ratio;
-      while (this.pcmAccum >= 1 && dsp.pcmReadPos !== dsp.pcmWritePos) {
-        this.pcmAccum -= 1;
-        dsp.pcmReadPos = (dsp.pcmReadPos + 1) & 0xFFFF;
-      }
+      // Only advance the resampling accumulator when source samples exist.
+      // Without this guard, pcmAccum drifts unboundedly while the source is
+      // empty (between DMA blocks), then on the next fill call the while-loop
+      // skips hundreds of fresh samples in one shot → near-silent SB output.
       if (((dsp.pcmWritePos - dsp.pcmReadPos) & 0xFFFF) > 0) {
+        this.pcmAccum += ratio;
+        while (this.pcmAccum >= 1) {
+          this.pcmAccum -= 1;
+          dsp.pcmReadPos = (dsp.pcmReadPos + 1) & 0xFFFF;
+          if (dsp.pcmReadPos === dsp.pcmWritePos) break;
+        }
         const s = dsp.pcmRing[dsp.pcmReadPos & 0xFFFF] * 0.5;
         bufL[i] += s;
         bufR[i] += s;

--- a/src/lib/emu/dos/soundblaster.ts
+++ b/src/lib/emu/dos/soundblaster.ts
@@ -271,11 +271,18 @@ export class SoundBlasterDSP {
           dma.currentAddr[1] = dma.baseAddr[1];
           dma.currentCount[1] = dma.baseCount[1];
         } else {
-          // Single-cycle: mask channel, stop transfer
+          // Single-cycle: mask channel, stop transfer.
+          // Only fire DSP IRQ if enough samples were transferred. Programs like
+          // STMIK use a small DMA buffer (4096) with a large DSP block (65001);
+          // the DMA TC fires early and zpollme reprograms it. On a real SB the
+          // DSP IRQ only fires after dmaLength bytes are received.
           dma.mask |= (1 << 1);
           this.dmaActive = false;
-          this.irqPending = true;
-          return true;
+          if (this.dmaTransferred >= this.dmaLength) {
+            this.irqPending = true;
+            return true;
+          }
+          return false;
         }
       }
     }

--- a/src/lib/emu/dos/soundblaster.ts
+++ b/src/lib/emu/dos/soundblaster.ts
@@ -277,13 +277,14 @@ export class SoundBlasterDSP {
     }
 
     if (this.dmaTransferred >= this.dmaLength) {
-      // Transfer complete
-      dma.status |= 0x02; // TC bit for channel 1
+      // DSP block complete — fire IRQ.
+      // Do NOT reload DMA registers here: the DMA controller manages its own
+      // address/count independently (reloaded only on real DMA TC in the inner
+      // loop above). For double-buffering, the DMA buffer is 2× the DSP block
+      // size and must continue from its current position, not restart.
       if (this.dmaAutoInit) {
-        // Reload from base registers
-        dma.currentAddr[1] = dma.baseAddr[1];
-        dma.currentCount[1] = dma.baseCount[1];
         this.dmaTransferred = 0;
+        this.dmaStartTime = performance.now();
       } else {
         this.dmaActive = false;
       }

--- a/src/lib/emu/dos/soundblaster.ts
+++ b/src/lib/emu/dos/soundblaster.ts
@@ -42,6 +42,10 @@ export class SoundBlasterDSP {
   irqPending = false;    // true when transfer complete, waiting for ACK
   private highSpeed = false;
 
+  // SB Pro mixer state
+  mixerAddr = 0;
+  stereoMode = false;
+
   // PCM output buffer for AudioWorklet consumption
   pcmRing = new Float32Array(65536);
   pcmWritePos = 0;
@@ -78,11 +82,6 @@ export class SoundBlasterDSP {
   }
 
   writeCommand(val: number): void {
-    // In high-speed DMA mode, the DSP is locked — it ignores all writes to the
-    // command port until a hardware reset (port 0x226). Programs (e.g. Second
-    // Reality) may write 0x48+0x91 from the ISR, expecting them to be ignored.
-    if (this.highSpeed && this.dmaActive) return;
-
     // If collecting parameters for a previous command
     if (this.expectedParams > 0) {
       this.pendingParams.push(val);

--- a/src/lib/emu/dos/soundblaster.ts
+++ b/src/lib/emu/dos/soundblaster.ts
@@ -78,6 +78,11 @@ export class SoundBlasterDSP {
   }
 
   writeCommand(val: number): void {
+    // In high-speed DMA mode, the DSP is locked — it ignores all writes to the
+    // command port until a hardware reset (port 0x226). Programs (e.g. Second
+    // Reality) may write 0x48+0x91 from the ISR, expecting them to be ignored.
+    if (this.highSpeed && this.dmaActive) return;
+
     // If collecting parameters for a previous command
     if (this.expectedParams > 0) {
       this.pendingParams.push(val);

--- a/src/lib/emu/emu-exec.ts
+++ b/src/lib/emu/emu-exec.ts
@@ -618,7 +618,9 @@ export function emuTick(emu: Emulator): void {
       emu._dosLastTimerTick += timerIntervalMs;
       // Cap: don't fall more than 200ms behind (prevents catch-up storm after tab background)
       if (now - emu._dosLastTimerTick > 200) emu._dosLastTimerTick = now;
-      emu._pendingHwInts.push(0x08);
+      const timerInt = emu._picMasterBase; // IRQ 0
+      if (!(emu._picMasterMask & 0x01) && !emu._pendingHwInts.includes(timerInt))
+        emu._pendingHwInts.push(timerInt);
       emu._dosHalted = false;
     }
     // Also wake on pending keyboard interrupt
@@ -715,15 +717,16 @@ export function emuTick(emu: Emulator): void {
       // DOS games do rapid VGA writes and yielding on each one kills throughput)
       if (!emu.isDOS && emu.screenDirty) { emu.screenDirty = false; break; }
 
-      // DOS timer interrupt (INT 08h) — frequency derived from PIT channel 0
+      // DOS timer interrupt — frequency derived from PIT channel 0
       if (emu.isDOS) {
         const pitReload = emu._pitCounters[0] || 0x10000;
         const timerIntervalMs = (pitReload / 1193182) * 1000;
         if (now - emu._dosLastTimerTick >= timerIntervalMs) {
-          if (!emu._pendingHwInts.includes(0x08)) {
+          const timerInt = emu._picMasterBase; // IRQ 0
+          if (!(emu._picMasterMask & 0x01) && !emu._pendingHwInts.includes(timerInt)) {
             emu._dosLastTimerTick += timerIntervalMs;
             if (now - emu._dosLastTimerTick > 200) emu._dosLastTimerTick = now;
-            emu._pendingHwInts.push(0x08);
+            emu._pendingHwInts.push(timerInt);
           }
           emu._dosHalted = false;
         }
@@ -790,10 +793,12 @@ export function emuTick(emu: Emulator): void {
       // technically incorrect but matches the practical behavior needed.
       const intNum = emu._pendingHwInts.shift()!;
       // Set PIC ISR bit for this IRQ (cleared by EOI from handler)
-      if (intNum >= 0x08 && intNum <= 0x0F) {
-        emu._picMasterISR |= (1 << (intNum - 0x08));
-      } else if (intNum >= 0x70 && intNum <= 0x77) {
-        emu._picSlaveISR |= (1 << (intNum - 0x70));
+      const masterBase = emu._picMasterBase;
+      const slaveBase = emu._picSlaveBase;
+      if (intNum >= masterBase && intNum < masterBase + 8) {
+        emu._picMasterISR |= (1 << (intNum - masterBase));
+      } else if (intNum >= slaveBase && intNum < slaveBase + 8) {
+        emu._picSlaveISR |= (1 << (intNum - slaveBase));
       }
       const biosDefault = emu._dosBiosDefaultVectors.get(intNum) ?? ((0xF000 << 16) | (intNum * 5));
       // Always read IVT memory first — programs chain multiple handlers
@@ -1219,6 +1224,10 @@ export function emuTick(emu: Emulator): void {
       syncVideoMemory(emu);
     }
   }
+
+  // Flush audio at end of tick — ensures the AudioWorklet ring buffer is fed
+  // even when scheduleImmediate starves setInterval's fill callback at 1x speed.
+  if (emu.isDOS) emu.dosAudio.flushAudio();
 
   if (emu.running && !emu.halted && !emu.waitingForMessage) {
     emu._tickCount++;

--- a/src/lib/emu/emu-load.ts
+++ b/src/lib/emu/emu-load.ts
@@ -1201,11 +1201,15 @@ function setupDosEnvironment(emu: Emulator, mz: import('./mz-loader').LoadedMZ):
   emu.dosAudio.readMemory = (addr: number) => emu.memory.readU8(addr);
   emu.dosAudio.writeMemory = (addr: number, val: number) => emu.memory.writeU8(addr, val);
   emu.dosAudio.onSBIRQ = () => {
-    if (!emu._pendingHwInts.includes(0x0F)) emu._pendingHwInts.push(0x0F);
+    const intNum = emu._picMasterBase + 7; // IRQ 7
+    if (!(emu._picMasterMask & 0x80) && !emu._pendingHwInts.includes(intNum))
+      emu._pendingHwInts.push(intNum);
   };
-  // Wire GUS IRQ (IRQ 5 = INT 0x0D)
+  // Wire GUS IRQ (IRQ 5)
   emu.dosAudio.onGUSIRQ = () => {
-    if (!emu._pendingHwInts.includes(0x0D)) emu._pendingHwInts.push(0x0D);
+    const intNum = emu._picMasterBase + 5; // IRQ 5
+    if (!(emu._picMasterMask & 0x20) && !emu._pendingHwInts.includes(intNum))
+      emu._pendingHwInts.push(intNum);
   };
   emu.dosAudio.gus.readMemory = (addr: number) => emu.memory.readU8(addr);
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,4 +11,11 @@ export default defineConfig({
 		...(process.env.VITE_ENABLE_ANALYZER === '1' ? [analyzer()] : []),
 		viteSingleFile(),
 	],
+	server: {
+		headers: {
+			// Required for SharedArrayBuffer (used by the AudioWorklet ring buffer).
+			'Cross-Origin-Opener-Policy': 'same-origin',
+			'Cross-Origin-Embedder-Policy': 'require-corp',
+		},
+	},
 });


### PR DESCRIPTION
### Summary

  - Fix SB PCM resampling: the pcmAccum accumulator drifted unboundedly when source samples were empty (between DMA blocks), then skipped hundreds of fresh samples on the next fill — root cause of silence at 1x speed in Prince of Persia
  - Fix auto-init DMA: reset dmaStartTime on block completion and stop reloading DMA registers from DSP (fixes double-buffering)
  - Fix single-cycle DMA TC: only fire DSP IRQ when dmaTransferred >= dmaLength (programs like STMIK use small DMA buffers with large DSP blocks)
  - Use dynamic PIC base vector (_picMasterBase) for timer/SB/GUS IRQ mapping instead of hardcoded values
  - Check PIC IMR before queueing IRQs
  - Add flushAudio() at end of DOS tick to prevent scheduleImmediate from starving the audio fill loop
  - Add COOP/COEP headers in vite config for SharedArrayBuffer support
  - Add SB Pro mixer port handling (0x224/0x225) with stereo mode tracking
  - Sync DMA position on port 0x02/0x03 read so programs polling the DMA address see current values

###  Test plan

  - Prince of Persia: SB sound effects work at 1x and 0.5x speed, no delay
  - OPL2 music still works (not choppy)
  - timeout 2 npx tsx tests/test-pop.mjs passes
