### PR TITLE
Add initial PBRUSH.EXE (Win16 Paintbrush) support and fix GDI rendering

### DIFF
--- a/src/components/EmulatorView.tsx
+++ b/src/components/EmulatorView.tsx
@@ -1058,7 +1058,6 @@ export function EmulatorView({ arrayBuffer, peInfo, additionalFiles, exeName, co
     // Block mouse events while a modal dialog/MessageBox is showing
     if (emu.messageBoxes.length > 0) return;
     if (emu.dialogState) return;
-
     // Resume AudioContext if suspended (user gesture)
     if (emu.audioContext?.state === 'suspended') emu.audioContext.resume();
 
@@ -1068,6 +1067,25 @@ export function EmulatorView({ arrayBuffer, peInfo, additionalFiles, exeName, co
     const y = Math.round((e.clientY - rect.top) * canvas.height / rect.height);
     const wParam = buildMKFlags(e);
     if (emu.capturedWindow) {
+      // Auto-release capture when no buttons pressed and cursor is outside the
+      // captured window (matches Windows behavior for WM_MOUSEMOVE tracking)
+      if (msg === WM_MOUSEMOVE && e.buttons === 0) {
+        const cw = emu.handles.get<WindowInfo>(emu.capturedWindow);
+        if (cw) {
+          let ox = 0, oy = 0;
+          let h = emu.capturedWindow;
+          while (h && h !== emu.mainWindow) {
+            const w = emu.handles.get<WindowInfo>(h);
+            if (!w) break;
+            ox += w.x; oy += w.y;
+            h = w.parent;
+          }
+          const rx = x - ox, ry = y - oy;
+          if (rx < 0 || ry < 0 || rx >= cw.width || ry >= cw.height) {
+            emu.capturedWindow = 0;
+          }
+        }
+      }
       // SetCapture: convert canvas coords to coords relative to captured window.
       // Walk up the parent chain to compute absolute canvas position, stopping
       // at the main window (canvas coords = main window's coordinate space).

--- a/src/lib/emu/emu-exec.ts
+++ b/src/lib/emu/emu-exec.ts
@@ -315,6 +315,8 @@ export function emuCallWndProc16(emu: Emulator, wndProc: number, hwnd: number, m
 
   const savedSP = emu.cpu.reg[4] & 0xFFFF;
   const savedDS = emu.cpu.ds;
+  const savedCS = emu.cpu.cs;
+  const savedEIP = emu.cpu.eip;
   const savedEBX = emu.cpu.reg[3];
   const savedESI = emu.cpu.reg[6];
   const savedEDI = emu.cpu.reg[7];
@@ -363,6 +365,8 @@ export function emuCallWndProc16(emu: Emulator, wndProc: number, hwnd: number, m
     // No segment contains this address — can't execute, bail out
     console.warn(`[MSG16] callWndProc16: no segment for wndProc=0x${wndProc.toString(16)} msg=0x${message.toString(16)} hwnd=0x${hwnd.toString(16)}`);
     emu.cpu.reg[4] = (emu.cpu.reg[4] & 0xFFFF0000) | (savedSP & 0xFFFF);
+    emu.cpu.cs = savedCS;
+    emu.cpu.eip = savedEIP;
     emu.cpu.ds = savedDS;
     emu.cpu.reg[3] = savedEBX;
     emu.cpu.reg[5] = savedEBP;
@@ -464,11 +468,14 @@ export function emuCallWndProc16(emu: Emulator, wndProc: number, hwnd: number, m
     emu.wndProcDepth = targetDepth;
   }
 
-  // Synchronous return — always restore SP, DS, and callee-saved registers.
+  // Synchronous return — always restore SP, DS, CS:EIP, and callee-saved registers.
   // SP restoration is critical: even if the WndProc completed normally
   // (RETF cleaned up args), we force SP back to guarantee no leak.
-  // DS restoration is critical for DLL wndProcs that use a different DS.
+  // CS:EIP restoration prevents the tick loop from seeing a stale WNDPROC_RETURN
+  // address and misinterpreting it as a new thunk invocation.
   emu.cpu.reg[4] = (emu.cpu.reg[4] & 0xFFFF0000) | (savedSP & 0xFFFF);
+  emu.cpu.cs = savedCS;
+  emu.cpu.eip = savedEIP;
   emu.cpu.ds = savedDS;
   emu.cpu.reg[3] = savedEBX;
   emu.cpu.reg[5] = savedEBP;

--- a/src/lib/emu/emu-load.ts
+++ b/src/lib/emu/emu-load.ts
@@ -343,6 +343,23 @@ export async function emuLoad(emu: Emulator, arrayBuffer: ArrayBuffer, peInfo: P
 
     rebuildThunkPages(emu);
 
+    // Pre-populate WIN.INI with standard Windows 3.1 defaults (if profile store exists)
+    // A real Windows install would have these values; apps like Paintbrush read them
+    // and fall back to printer-based calculations when missing, which we can't emulate.
+    if (emu.profileStore) {
+      const ps = emu.profileStore;
+      const winIni = 'win.ini';
+      // Screen-sized defaults for Paintbrush (width/height in current unit, positive = direct)
+      const defW = Math.round((emu.screenWidth || 640) * 2.54 / 9.6); // pixels → ~cm
+      const defH = Math.round((emu.screenHeight || 480) * 2.54 / 9.6);
+      if (!ps.getString(winIni, 'Paintbrush', 'width', '')) {
+        ps.writeString(winIni, 'Paintbrush', 'width', String(defW));
+      }
+      if (!ps.getString(winIni, 'Paintbrush', 'height', '')) {
+        ps.writeString(winIni, 'Paintbrush', 'height', String(defH));
+      }
+    }
+
     // Pre-load menu items from NE resources so GetMenuState works during init
     if (!emu.menuItems) {
       const menus = extractMenus(peInfo, arrayBuffer);

--- a/src/lib/emu/emu-load.ts
+++ b/src/lib/emu/emu-load.ts
@@ -258,6 +258,10 @@ export async function emuLoad(emu: Emulator, arrayBuffer: ArrayBuffer, peInfo: P
     // Set up CPU for 16-bit mode
     emu.cpu.use32 = false;
     emu.cpu.segBases = emu.ne.selectorToBase;
+    // Build segment limits from NE segment info (selector → limit)
+    for (const seg of emu.ne.segments) {
+      emu.cpu.segLimits.set(seg.selector, seg.minAlloc - 1);
+    }
     emu.cpu.cs = emu.ne.codeSegSelector;
     emu.cpu.ds = emu.ne.dataSegSelector;
     emu.cpu.es = emu.ne.dataSegSelector;
@@ -937,6 +941,7 @@ async function loadNEDlls(emu: Emulator): Promise<NEDllEntry[]> {
     // Add DLL segments to the main segment list (for WILD EIP validation)
     for (const seg of dll.segments) {
       ne.segments.push(seg);
+      emu.cpu.segLimits.set(seg.selector, seg.minAlloc - 1);
     }
 
     console.log(`[NE DLL] ${modName}: ${dll.segments.length} segments, ${dll.entryPoints.size} exports, ${dll.apiMap.size} imports`);

--- a/src/lib/emu/emu-window.ts
+++ b/src/lib/emu/emu-window.ts
@@ -330,6 +330,28 @@ export function releaseChildDC(emu: Emulator, hdc: number): void {
   }
 }
 
+/**
+ * Read destination pixels at transform-aware canvas coordinates.
+ * getImageData ignores canvas transforms, so we manually apply the offset.
+ */
+export function dcGetImageData(dc: DCInfo, x: number, y: number, w: number, h: number): ImageData {
+  const tf = dc.ctx.getTransform();
+  const cx = Math.round(tf.e + x * tf.a);
+  const cy = Math.round(tf.f + y * tf.d);
+  return dc.ctx.getImageData(cx, cy, w, h);
+}
+
+/**
+ * Write pixels via temp canvas + drawImage to respect transform + clip.
+ * putImageData ignores both canvas transform and clip region;
+ * drawImage respects both.
+ */
+export function dcPutImageData(dc: DCInfo, imgData: ImageData, x: number, y: number): void {
+  const tmp = new OffscreenCanvas(imgData.width, imgData.height);
+  tmp.getContext('2d')!.putImageData(imgData, 0, 0);
+  dc.ctx.drawImage(tmp, x, y);
+}
+
 export function syncDCToCanvas(emu: Emulator, _hdc: number): void {
   // Window DCs draw directly to the main canvas — nothing to sync
   // Memory DCs are OffscreenCanvas which need explicit BitBlt

--- a/src/lib/emu/emu-window.ts
+++ b/src/lib/emu/emu-window.ts
@@ -134,10 +134,34 @@ export function getWindowDC(emu: Emulator, hwnd: number): number {
 
   const existing = emu.windowDCs.get(hwnd);
   if (existing && !needsTranslate && !hasDomCanvas) return existing;
-  // Free old DC for translated/domCanvas windows to avoid stale state.
-  // Only call releaseChildDC (ctx.restore) if the DC is still in childDCSet —
-  // if EndPaint already restored it, the save stack is already balanced.
-  if (existing && (needsTranslate || hasDomCanvas)) {
+
+  // For child windows sharing the main canvas, reuse existing DC (preserving
+  // app-set attributes like textColor, selectedBrush) but refresh the canvas
+  // state (save/transform/clip) which must be balanced per GetDC/ReleaseDC.
+  if (existing && needsTranslate && wnd) {
+    if (childDCSet.has(existing)) {
+      releaseChildDC(emu, existing);
+    }
+    const dc = getDC(emu, existing);
+    if (dc) {
+      const origin = isPopup ? { x: wnd.x || 0, y: wnd.y || 0 } : getWindowOrigin(emu, hwnd);
+      let ccsYOffset = 0;
+      const internalH = (wnd as any)._ccsInternalHeight;
+      if (internalH && internalH > wnd.height) {
+        ccsYOffset = Math.round((internalH - wnd.height) / 2);
+      }
+      dc.ctx.save();
+      dc.ctx.setTransform(1, 0, 0, 1, origin.x, origin.y + ccsYOffset);
+      dc.ctx.beginPath();
+      dc.ctx.rect(0, -ccsYOffset, wnd.width, wnd.height);
+      dc.ctx.clip();
+      childDCSet.add(existing);
+      return existing;
+    }
+  }
+
+  // Free old DC for domCanvas windows
+  if (existing && hasDomCanvas) {
     if (childDCSet.has(existing)) {
       releaseChildDC(emu, existing);
     }
@@ -185,10 +209,6 @@ export function getWindowDC(emu: Emulator, hwnd: number): number {
   // For windows sharing the main canvas, apply coordinate offset and clip
   if (needsTranslate && wnd) {
     const origin = isPopup ? { x: wnd.x || 0, y: wnd.y || 0 } : getWindowOrigin(emu, hwnd);
-    // CCS toolbar: the x86 COMMCTRL code computes button positions based on
-    // its internally-desired height (e.g. 47px), but the frame forces the
-    // toolbar to a smaller height (e.g. 27px). The button rects are centered
-    // for the internal height, so we shift the DC origin down to compensate.
     let ccsYOffset = 0;
     const internalH = (wnd as any)._ccsInternalHeight;
     if (internalH && internalH > wnd.height) {

--- a/src/lib/emu/win16/commdlg.ts
+++ b/src/lib/emu/win16/commdlg.ts
@@ -185,8 +185,46 @@ export function registerWin16Commdlg(emu: Emulator): void {
   commdlg.register('ChooseFont', 4, () => 0, 15);
 
   // Ordinal 20: PrintDlg(lpPd) — 4 bytes (segptr)
-  // Returns 0 = user cancelled
-  commdlg.register('PrintDlg', 4, () => 0, 20);
+  // Allocate a default DEVMODE16 so callers can read paper size
+  commdlg.register('PrintDlg', 4, () => {
+    const [lpPdRaw] = emu.readPascalArgs16([4]);
+    const lpPd = emu.resolveFarPtr(lpPdRaw);
+    if (!lpPd) return 0;
+
+    // Allocate DEVMODE16 on a 64KB-aligned block (acts as its own segment/selector)
+    const DEVMODE_SIZE = 68;
+    const addr = emu.allocHeap64K(DEVMODE_SIZE);
+    const selector = addr >>> 16;
+    // Register in segBases so GlobalLock can resolve it, and in segLimits for LSL
+    emu.cpu.segBases.set(selector, addr);
+    emu.cpu.segLimits.set(selector, DEVMODE_SIZE - 1);
+
+    // dmDeviceName (32 bytes at offset 0)
+    const name = 'Default Printer';
+    for (let i = 0; i < name.length; i++) emu.memory.writeU8(addr + i, name.charCodeAt(i));
+
+    const DM_ORIENTATION = 0x0001;
+    const DM_PAPERSIZE = 0x0002;
+    const DM_PAPERLENGTH = 0x0004;
+    const DM_PAPERWIDTH = 0x0008;
+    emu.memory.writeU16(addr + 32, 0x030A); // dmSpecVersion
+    emu.memory.writeU16(addr + 36, DEVMODE_SIZE); // dmSize
+    emu.memory.writeU16(addr + 40, DM_ORIENTATION | DM_PAPERSIZE | DM_PAPERLENGTH | DM_PAPERWIDTH); // dmFields
+    emu.memory.writeU16(addr + 42, 1);    // dmOrientation = PORTRAIT
+    emu.memory.writeU16(addr + 44, 1);    // dmPaperSize = DMPAPER_LETTER
+    emu.memory.writeU16(addr + 46, 2794); // dmPaperLength = 279.4mm (11")
+    emu.memory.writeU16(addr + 48, 2159); // dmPaperWidth = 215.9mm (8.5")
+    emu.memory.writeU16(addr + 56, 300);  // dmPrintQuality = 300 DPI
+
+    // Write hDevMode into PRINTDLG16 at offset +6
+    emu.memory.writeU16(lpPd + 6, selector);
+
+    // Write a dummy hDC at offset +10
+    const hDC = emu.getWindowDC(emu.mainWindow || 0);
+    emu.memory.writeU16(lpPd + 10, hDC);
+
+    return 1; // success
+  }, 20);
 
   // Ordinal 26: CommDlgExtendedError() — 0 bytes
   commdlg.register('CommDlgExtendedError', 0, () => 0, 26);

--- a/src/lib/emu/win16/gdi.ts
+++ b/src/lib/emu/win16/gdi.ts
@@ -722,7 +722,6 @@ export function registerWin16Gdi(emu: Emulator): void {
     const h = (hRaw << 16) >> 16;
     const dc = emu.getDC(hdc);
     if (!dc) return 0;
-
     if (rop === BLACKNESS16) {
       dc.ctx.fillStyle = '#000';
       dc.ctx.fillRect(x, y, w, h);
@@ -940,19 +939,29 @@ export function registerWin16Gdi(emu: Emulator): void {
       const dstData = dcGetImageData(dstDC, xDst, yDst, w, h);
       const srcData = srcDC.ctx.getImageData(xSrc, ySrc, w, h);
 
-      // Get pattern brush colors
+      // Get pattern brush
       const brush = emu.getBrush(dstDC.selectedBrush);
-      const txC = dstDC.textColor, bkC = dstDC.bkColor;
-      const txR = txC & 0xFF, txG = (txC >> 8) & 0xFF, txB = (txC >> 16) & 0xFF;
-      const bkR = bkC & 0xFF, bkG = (bkC >> 8) & 0xFF, bkB = (bkC >> 16) & 0xFF;
       let patPixels: Uint8ClampedArray | null = null;
       let patW = 8, patH = 8;
+      let patIsMono = false;
       if (brush?.patternBitmap) {
         const patCtx = brush.patternBitmap.getContext('2d')!;
         patW = brush.patternBitmap.width || 8;
         patH = brush.patternBitmap.height || 8;
         patPixels = patCtx.getImageData(0, 0, patW, patH).data;
+        // Detect monochrome pattern (only pure black and white pixels)
+        patIsMono = true;
+        for (let pi = 0; pi < patPixels.length; pi += 4) {
+          const pr = patPixels[pi], pg = patPixels[pi+1], pb = patPixels[pi+2];
+          if (!((pr === 0 && pg === 0 && pb === 0) || (pr === 255 && pg === 255 && pb === 255))) {
+            patIsMono = false; break;
+          }
+        }
       }
+      // For mono patterns, colorize with textColor/bkColor (Windows behavior)
+      const txC = dstDC.textColor, bkC = dstDC.bkColor;
+      const txR = txC & 0xFF, txG = (txC >> 8) & 0xFF, txB = (txC >> 16) & 0xFF;
+      const bkR = bkC & 0xFF, bkG = (bkC >> 8) & 0xFF, bkB = (bkC >> 16) & 0xFF;
 
       // For pattern tiling, compute canvas-space origin
       const tf = dstDC.ctx.getTransform();
@@ -965,15 +974,24 @@ export function registerWin16Gdi(emu: Emulator): void {
           const i = (py * w + px) * 4;
           // Source (mask) pixel
           const sr = srcData.data[i], sg = srcData.data[i+1], sb = srcData.data[i+2];
-          // Pattern pixel (from brush, colorized with textColor/bkColor for mono)
+          // Pattern pixel
           let pR: number, pG: number, pB: number;
           if (patPixels) {
             const tileX = ((cX + px) % patW + patW) % patW;
             const tileY = ((cY + py) % patH + patH) % patH;
-            const isBlack = patPixels[(tileY * patW + tileX) * 4] === 0;
-            pR = isBlack ? txR : bkR;
-            pG = isBlack ? txG : bkG;
-            pB = isBlack ? txB : bkB;
+            const pOff = (tileY * patW + tileX) * 4;
+            if (patIsMono) {
+              // Mono pattern: colorize black→textColor, white→bkColor
+              const isBlack = patPixels[pOff] === 0;
+              pR = isBlack ? txR : bkR;
+              pG = isBlack ? txG : bkG;
+              pB = isBlack ? txB : bkB;
+            } else {
+              // Color pattern: use actual pixel colors
+              pR = patPixels[pOff];
+              pG = patPixels[pOff + 1];
+              pB = patPixels[pOff + 2];
+            }
           } else {
             pR = brush ? (brush.color & 0xFF) : 0;
             pG = brush ? ((brush.color >> 8) & 0xFF) : 0;
@@ -1775,13 +1793,29 @@ export function registerWin16Gdi(emu: Emulator): void {
     if (!bmp || !lpBits || cbBuffer <= 0) return 0;
     const imgData = bmp.ctx.createImageData(bmp.width, bmp.height);
     const px = imgData.data;
-    const total = Math.min(cbBuffer, bmp.width * bmp.height);
-    for (let i = 0; i < total; i++) {
-      const v = emu.memory.readU8(lpBits + i);
-      px[i * 4] = v; px[i * 4 + 1] = v; px[i * 4 + 2] = v; px[i * 4 + 3] = 255;
+    if (bmp.monochrome) {
+      // 1bpp: each byte contains 8 pixels (MSB = leftmost), rows WORD-aligned
+      const bytesPerRow = Math.ceil(bmp.width / 16) * 2;
+      for (let y = 0; y < bmp.height; y++) {
+        for (let x = 0; x < bmp.width; x++) {
+          const byteIdx = y * bytesPerRow + (x >> 3);
+          if (byteIdx >= cbBuffer) break;
+          const bit = (emu.memory.readU8(lpBits + byteIdx) >> (7 - (x & 7))) & 1;
+          const off = (y * bmp.width + x) * 4;
+          const v = bit ? 255 : 0; // 1 = white, 0 = black
+          px[off] = v; px[off + 1] = v; px[off + 2] = v; px[off + 3] = 255;
+        }
+      }
+    } else {
+      // Color bitmap: each byte is one pixel channel (simple grayscale fallback)
+      const total = Math.min(cbBuffer, bmp.width * bmp.height);
+      for (let i = 0; i < total; i++) {
+        const v = emu.memory.readU8(lpBits + i);
+        px[i * 4] = v; px[i * 4 + 1] = v; px[i * 4 + 2] = v; px[i * 4 + 3] = 255;
+      }
     }
     bmp.ctx.putImageData(imgData, 0, 0);
-    return total;
+    return cbBuffer;
   }, 106);
 
   // Ordinal 117: SetDCOrg(hdc, x, y) — pascal, 6 bytes

--- a/src/lib/emu/win16/gdi.ts
+++ b/src/lib/emu/win16/gdi.ts
@@ -3,6 +3,7 @@ import type { DCInfo, BitmapInfo, BrushInfo, PenInfo, PaletteInfo } from '../win
 import { OPAQUE } from '../win32/types';
 import { fillTextBitmap } from '../emu-render';
 import { decodeDib } from '../../pe/decode-dib';
+import { dcGetImageData, dcPutImageData } from '../emu-window';
 
 function bresenhamLine(ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D, x0: number, y0: number, x1: number, y1: number): void {
   const dx = Math.abs(x1 - x0), dy = Math.abs(y1 - y0);
@@ -495,6 +496,9 @@ export function registerWin16Gdi(emu: Emulator): void {
         let pr = 0, pg = 0, pb = 0;
         if (pen) { pr = pen.color & 0xFF; pg = (pen.color >> 8) & 0xFF; pb = (pen.color >> 16) & 0xFF; }
         const cw = dc.canvas.width || 1, ch = dc.canvas.height || 1;
+        // getImageData ignores canvas transforms — apply offset manually
+        const tf = dc.ctx.getTransform();
+        const oX = Math.round(tf.e), oY = Math.round(tf.f);
         const imgData = dc.ctx.getImageData(0, 0, cw, ch);
         const d = imgData.data;
         let x0 = dc.penPosX, y0 = dc.penPosY, x1 = x, y1 = y;
@@ -502,8 +506,9 @@ export function registerWin16Gdi(emu: Emulator): void {
         const sx = x0 < x1 ? 1 : -1, sy = y0 < y1 ? 1 : -1;
         let err = dx - dy;
         while (true) {
-          if (x0 >= 0 && x0 < cw && y0 >= 0 && y0 < ch) {
-            const off = (y0 * cw + x0) * 4;
+          const cx = x0 + oX, cy = y0 + oY;
+          if (cx >= 0 && cx < cw && cy >= 0 && cy < ch) {
+            const off = (cy * cw + cx) * 4;
             const dr = d[off], dg = d[off+1], db = d[off+2];
             let rr: number, rg: number, rb: number;
             switch (rop2) {
@@ -607,15 +612,19 @@ export function registerWin16Gdi(emu: Emulator): void {
     const fillR = brush.color & 0xFF, fillG = (brush.color >> 8) & 0xFF, fillB = (brush.color >> 16) & 0xFF;
     const bndR = crColor & 0xFF, bndG = (crColor >> 8) & 0xFF, bndB = (crColor >> 16) & 0xFF;
     const w = dc.canvas.width, h = dc.canvas.height;
-    if (x < 0 || x >= w || y < 0 || y >= h) return 0;
+    // getImageData ignores canvas transforms — apply offset manually
+    const tf = dc.ctx.getTransform();
+    const oX = Math.round(tf.e), oY = Math.round(tf.f);
+    const sx = x + oX, sy = y + oY;
+    if (sx < 0 || sx >= w || sy < 0 || sy >= h) return 0;
     const imgData = dc.ctx.getImageData(0, 0, w, h);
     const px = imgData.data;
     const isBoundary = (i: number) => px[i] === bndR && px[i + 1] === bndG && px[i + 2] === bndB;
-    const startIdx = (y * w + x) * 4;
+    const startIdx = (sy * w + sx) * 4;
     if (isBoundary(startIdx)) return 0;
     const visited = new Uint8Array(w * h);
-    const stack = [x + y * w];
-    visited[x + y * w] = 1;
+    const stack = [sx + sy * w];
+    visited[sx + sy * w] = 1;
     while (stack.length > 0) {
       const pos = stack.pop()!;
       const px0 = pos % w, py0 = (pos / w) | 0;
@@ -872,7 +881,7 @@ export function registerWin16Gdi(emu: Emulator): void {
 
     if (rop === SRCCOPY16) {
       if (srcMono || dstMono) {
-        dstDC.ctx.putImageData(getConvertedSrcData(), xDst, yDst);
+        dcPutImageData(dstDC, getConvertedSrcData(), xDst, yDst);
       } else {
         dstDC.ctx.drawImage(srcDC.canvas, xSrc, ySrc, w, h, xDst, yDst, w, h);
       }
@@ -884,34 +893,34 @@ export function registerWin16Gdi(emu: Emulator): void {
         px[i+1] = 255 - px[i+1];
         px[i+2] = 255 - px[i+2];
       }
-      dstDC.ctx.putImageData(srcData, xDst, yDst);
+      dcPutImageData(dstDC, srcData, xDst, yDst);
     } else if (rop === SRCPAINT16) {
       const srcData = getConvertedSrcData();
-      const dstData = dstDC.ctx.getImageData(xDst, yDst, w, h);
+      const dstData = dcGetImageData(dstDC, xDst, yDst, w, h);
       for (let i = 0; i < srcData.data.length; i += 4) {
         dstData.data[i] |= srcData.data[i];
         dstData.data[i+1] |= srcData.data[i+1];
         dstData.data[i+2] |= srcData.data[i+2];
       }
-      dstDC.ctx.putImageData(dstData, xDst, yDst);
+      dcPutImageData(dstDC, dstData, xDst, yDst);
     } else if (rop === SRCAND16) {
       const srcData = getConvertedSrcData();
-      const dstData = dstDC.ctx.getImageData(xDst, yDst, w, h);
+      const dstData = dcGetImageData(dstDC, xDst, yDst, w, h);
       for (let i = 0; i < srcData.data.length; i += 4) {
         dstData.data[i] &= srcData.data[i];
         dstData.data[i+1] &= srcData.data[i+1];
         dstData.data[i+2] &= srcData.data[i+2];
       }
-      dstDC.ctx.putImageData(dstData, xDst, yDst);
+      dcPutImageData(dstDC, dstData, xDst, yDst);
     } else if (rop === SRCINVERT16) {
       const srcData = getConvertedSrcData();
-      const dstData = dstDC.ctx.getImageData(xDst, yDst, w, h);
+      const dstData = dcGetImageData(dstDC, xDst, yDst, w, h);
       for (let i = 0; i < srcData.data.length; i += 4) {
         dstData.data[i] ^= srcData.data[i];
         dstData.data[i+1] ^= srcData.data[i+1];
         dstData.data[i+2] ^= srcData.data[i+2];
       }
-      dstDC.ctx.putImageData(dstData, xDst, yDst);
+      dcPutImageData(dstDC, dstData, xDst, yDst);
     } else if (rop === 0xe20746) {
       // ROP 0xE20746: DSPDxax = (Dst ^ (Src & (Pat ^ Dst)))
       //   equivalent to: (D AND NOT S) OR (P AND S)
@@ -927,12 +936,8 @@ export function registerWin16Gdi(emu: Emulator): void {
       // 55AA pattern brush (hbrMonoDither): applies a checkerboard pattern
       // through a mono mask to dim the button background.
       //
-      // Uses transform-aware getImageData/putImageData because child window
-      // DCs share the main canvas with a translate+clip transform.
-      const tf = dstDC.ctx.getTransform();
-      const cX = Math.round(tf.e + xDst * tf.a);
-      const cY = Math.round(tf.f + yDst * tf.d);
-      const dstData = dstDC.ctx.getImageData(cX, cY, w, h);
+      // Uses dcGetImageData/dcPutImageData for transform + clip awareness.
+      const dstData = dcGetImageData(dstDC, xDst, yDst, w, h);
       const srcData = srcDC.ctx.getImageData(xSrc, ySrc, w, h);
 
       // Get pattern brush colors
@@ -948,6 +953,11 @@ export function registerWin16Gdi(emu: Emulator): void {
         patH = brush.patternBitmap.height || 8;
         patPixels = patCtx.getImageData(0, 0, patW, patH).data;
       }
+
+      // For pattern tiling, compute canvas-space origin
+      const tf = dstDC.ctx.getTransform();
+      const cX = Math.round(tf.e + xDst * tf.a);
+      const cY = Math.round(tf.f + yDst * tf.d);
 
       // Apply Wine's formula per-channel: Dst ^ (Src & (Pat ^ Dst))
       for (let py = 0; py < h; py++) {
@@ -977,7 +987,7 @@ export function registerWin16Gdi(emu: Emulator): void {
           dstData.data[i+3] = 255;
         }
       }
-      dstDC.ctx.putImageData(dstData, cX, cY);
+      dcPutImageData(dstDC, dstData, xDst, yDst);
     } else {
       // Fallback for other unimplemented ROPs.
       dstDC.ctx.drawImage(srcDC.canvas, xSrc, ySrc, w, h, xDst, yDst, w, h);
@@ -1547,7 +1557,11 @@ export function registerWin16Gdi(emu: Emulator): void {
     const dc = emu.getDC(hdc);
     if (dc) {
       try {
-        const imgData = dc.ctx.getImageData(x, y, 1, 1);
+        // getImageData ignores canvas transforms — apply offset manually
+        const tf = dc.ctx.getTransform();
+        const cx = Math.round(tf.e + x * tf.a);
+        const cy = Math.round(tf.f + y * tf.d);
+        const imgData = dc.ctx.getImageData(cx, cy, 1, 1);
         const [r, g, b] = imgData.data;
         return r | (g << 8) | (b << 16);
       } catch { /* empty */ }
@@ -2104,7 +2118,11 @@ export function registerWin16Gdi(emu: Emulator): void {
     const fillR = brush.color & 0xFF, fillG = (brush.color >> 8) & 0xFF, fillB = (brush.color >> 16) & 0xFF;
     const tgtR = crColor & 0xFF, tgtG = (crColor >> 8) & 0xFF, tgtB = (crColor >> 16) & 0xFF;
     const w = dc.canvas.width, h = dc.canvas.height;
-    if (x < 0 || x >= w || y < 0 || y >= h) return 0;
+    // getImageData ignores canvas transforms — apply offset manually
+    const tf = dc.ctx.getTransform();
+    const oX = Math.round(tf.e), oY = Math.round(tf.f);
+    const sx = x + oX, sy = y + oY;
+    if (sx < 0 || sx >= w || sy < 0 || sy >= h) return 0;
     const imgData = dc.ctx.getImageData(0, 0, w, h);
     const px = imgData.data;
 
@@ -2112,20 +2130,20 @@ export function registerWin16Gdi(emu: Emulator): void {
     let shouldFill: (i: number) => boolean;
     if (fuFillType === FLOODFILLSURFACE) {
       // Fill while pixel matches crColor (surface fill)
-      const startIdx = (y * w + x) * 4;
+      const startIdx = (sy * w + sx) * 4;
       if (px[startIdx] !== tgtR || px[startIdx + 1] !== tgtG || px[startIdx + 2] !== tgtB) return 0;
       if (fillR === tgtR && fillG === tgtG && fillB === tgtB) return 1; // already filled
       shouldFill = (i: number) => px[i] === tgtR && px[i + 1] === tgtG && px[i + 2] === tgtB;
     } else {
       // Fill until boundary color hit
-      const startIdx = (y * w + x) * 4;
+      const startIdx = (sy * w + sx) * 4;
       if (px[startIdx] === tgtR && px[startIdx + 1] === tgtG && px[startIdx + 2] === tgtB) return 0;
       shouldFill = (i: number) => !(px[i] === tgtR && px[i + 1] === tgtG && px[i + 2] === tgtB);
     }
 
     const visited = new Uint8Array(w * h);
-    const stack = [x + y * w];
-    visited[x + y * w] = 1;
+    const stack = [sx + sy * w];
+    visited[sx + sy * w] = 1;
     while (stack.length > 0) {
       const pos = stack.pop()!;
       const px0 = pos % w;
@@ -2419,7 +2437,7 @@ export function registerWin16Gdi(emu: Emulator): void {
       }
     }
 
-    dc.ctx.putImageData(imgData, (xDest << 16) >> 16, (yDest << 16) >> 16);
+    dcPutImageData(dc, imgData, (xDest << 16) >> 16, (yDest << 16) >> 16);
     emu.syncDCToCanvas(hdc);
     return drawH;
   }, 443);

--- a/src/lib/emu/win16/gdi.ts
+++ b/src/lib/emu/win16/gdi.ts
@@ -1466,10 +1466,10 @@ export function registerWin16Gdi(emu: Emulator): void {
     const caps: Record<number, number> = {
       [DRIVERVERSION]: 0x0300,
       [TECHNOLOGY]: 1,     // DT_RASDISPLAY
-      [HORZSIZE]: 320,
-      [VERTSIZE]: 240,
-      [HORZRES]: 640,
-      [VERTRES]: 480,
+      [HORZSIZE]: Math.round((emu.screenWidth || 640) * 25.4 / 96),
+      [VERTSIZE]: Math.round((emu.screenHeight || 480) * 25.4 / 96),
+      [HORZRES]: emu.screenWidth || 640,
+      [VERTRES]: emu.screenHeight || 480,
       [BITSPIXEL]: 8,
       [PLANES]: 1,
       [NUMBRUSHES]: 256,

--- a/src/lib/emu/win16/kernel/memory.ts
+++ b/src/lib/emu/win16/kernel/memory.ts
@@ -88,6 +88,13 @@ export function registerKernelMemory(kernel: Win16Module, emu: Emulator, state: 
     const handle = emu.readArg16(0);
     const addr = state.globalHandleToAddr.get(handle);
     if (addr === undefined) {
+      // Fallback: if the handle is a valid selector (e.g. allocated by a DLL stub),
+      // treat it as a lockable segment
+      if (emu.cpu.segBases.has(handle)) {
+        emu.cpu.setReg16(2, handle);
+        emu.cpu.reg[0] = (emu.cpu.reg[0] & 0xFFFF0000);
+        return (handle << 16) >>> 0;
+      }
       emu.cpu.setReg16(2, 0);
       emu.cpu.reg[0] = (emu.cpu.reg[0] & 0xFFFF0000);
       return 0;

--- a/src/lib/emu/win16/kernel/memory.ts
+++ b/src/lib/emu/win16/kernel/memory.ts
@@ -17,6 +17,7 @@ export function registerKernelMemory(kernel: Win16Module, emu: Emulator, state: 
     const addr = emu.allocHeap64K(allocSize);
     const selector = state.nextGlobalSelector++;
     emu.cpu.segBases.set(selector, addr);
+    emu.cpu.segLimits.set(selector, allocSize - 1);
     state.globalHandleToAddr.set(selector, addr);
     state.globalHandleToSize.set(selector, allocSize);
     state.globalHandleFlags.set(selector, flags & 0xFFFF);
@@ -57,6 +58,7 @@ export function registerKernelMemory(kernel: Win16Module, emu: Emulator, state: 
       for (let i = oldSize; i < size; i++) emu.memory.writeU8(newAddr + i, 0);
     }
     emu.cpu.segBases.set(handle, newAddr);
+    emu.cpu.segLimits.set(handle, (size || 1) - 1);
     state.globalHandleToAddr.set(handle, newAddr);
     state.globalHandleToSize.set(handle, size);
     console.log(`[KERNEL16] GlobalReAlloc(handle=0x${handle.toString(16)}, size=${size}, flags=0x${flags.toString(16)}) old=0x${(oldAddr ?? 0).toString(16)} → new=0x${newAddr.toString(16)}`);

--- a/src/lib/emu/win16/kernel/profile.ts
+++ b/src/lib/emu/win16/kernel/profile.ts
@@ -20,7 +20,9 @@ export function registerKernelProfile(kernel: Win16Module, emu: Emulator, _state
 
   // --- Ordinal 57: GetProfileInt(lpAppName:str, lpKeyName:str, nDefault:s_word) — 10 bytes ---
   kernel.register('GetProfileInt', 10, () => {
-    const [lpAppNameRaw, lpKeyNameRaw, nDefault] = emu.readPascalArgs16([4, 4, 2]);
+    const [lpAppNameRaw, lpKeyNameRaw, nDefaultRaw] = emu.readPascalArgs16([4, 4, 2]);
+    // nDefault is a signed word (s_word) — sign-extend from 16-bit
+    const nDefault = (nDefaultRaw << 16 >> 16);
     const s = ps();
     if (!s) return nDefault;
     const lpAppName = emu.resolveFarPtr(lpAppNameRaw);

--- a/src/lib/emu/win16/shell.ts
+++ b/src/lib/emu/win16/shell.ts
@@ -12,12 +12,13 @@ export function registerWin16Shell(emu: Emulator): void {
 
   // --- Registry APIs ---
 
-  // RegOpenKey(HKEY hKey, LPCSTR lpSubKey, PHKEY phkResult)
+  // RegOpenKey(HKEY hKey, LPCSTR lpSubKey, PHKEY phkResult) — pascal(long, str, ptr)
   shell.register('RegOpenKey', 12, () => {
-    const hKey = emu.readArg16DWord(0);
-    const lpSubKey = emu.readArg16FarPtr(4);
+    const [hKeyRaw, lpSubKeyRaw, phkResultRaw] = emu.readPascalArgs16([4, 4, 4]);
+    const hKey = hKeyRaw;
+    const lpSubKey = emu.resolveFarPtr(lpSubKeyRaw);
     const subKey = lpSubKey ? emu.memory.readCString(lpSubKey) : '';
-    const phkResult = emu.readArg16FarPtr(8);
+    const phkResult = emu.resolveFarPtr(phkResultRaw);
     const s = store();
     if (s) {
       const h = s.openKey(hKey, subKey);
@@ -31,12 +32,13 @@ export function registerWin16Shell(emu: Emulator): void {
     return ERROR_SUCCESS;
   }, 1);
 
-  // RegCreateKey(HKEY hKey, LPCSTR lpSubKey, PHKEY phkResult)
+  // RegCreateKey(HKEY hKey, LPCSTR lpSubKey, PHKEY phkResult) — pascal(long, str, ptr)
   shell.register('RegCreateKey', 12, () => {
-    const hKey = emu.readArg16DWord(0);
-    const lpSubKey = emu.readArg16FarPtr(4);
+    const [hKeyRaw, lpSubKeyRaw, phkResultRaw] = emu.readPascalArgs16([4, 4, 4]);
+    const hKey = hKeyRaw;
+    const lpSubKey = emu.resolveFarPtr(lpSubKeyRaw);
     const subKey = lpSubKey ? emu.memory.readCString(lpSubKey) : '';
-    const phkResult = emu.readArg16FarPtr(8);
+    const phkResult = emu.resolveFarPtr(phkResultRaw);
     const s = store();
     if (s) {
       const r = s.createKey(hKey, subKey);
@@ -49,9 +51,9 @@ export function registerWin16Shell(emu: Emulator): void {
     return ERROR_SUCCESS;
   }, 2);
 
-  // RegCloseKey(HKEY hKey)
+  // RegCloseKey(HKEY hKey) — pascal(long)
   shell.register('RegCloseKey', 4, () => {
-    const hKey = emu.readArg16DWord(0);
+    const [hKey] = emu.readPascalArgs16([4]);
     const s = store();
     if (s) s.closeKey(hKey);
     return ERROR_SUCCESS;
@@ -60,35 +62,38 @@ export function registerWin16Shell(emu: Emulator): void {
   // RegDeleteKey(HKEY hKey, LPCSTR lpSubKey)
   shell.register('RegDeleteKey', 8, () => ERROR_SUCCESS, 4);
 
-  // RegSetValue(HKEY hKey, LPCSTR lpSubKey, DWORD dwType, LPCSTR lpData, DWORD cbData)
+  // RegSetValue(HKEY hKey, LPCSTR lpSubKey, DWORD dwType, LPCSTR lpData, DWORD cbData) — pascal(long, str, long, str, long)
   shell.register('RegSetValue', 20, () => {
-    const hKey = emu.readArg16DWord(0);
-    const lpSubKey = emu.readArg16FarPtr(4);
+    const [hKeyRaw, lpSubKeyRaw, _dwType, lpDataRaw, cbData] = emu.readPascalArgs16([4, 4, 4, 4, 4]);
+    const hKey = hKeyRaw;
+    const lpSubKey = emu.resolveFarPtr(lpSubKeyRaw);
     const subKey = lpSubKey ? emu.memory.readCString(lpSubKey) : '';
-    // dwType at offset 8 (always REG_SZ for RegSetValue)
-    const lpData = emu.readArg16FarPtr(12);
-    const cbData = emu.readArg16DWord(16);
+    const lpData = emu.resolveFarPtr(lpDataRaw);
+    // For REG_SZ, cbData=0 means use lstrlen(lpData) (standard Win16 behavior)
+    const dataStr = lpData ? emu.memory.readCString(lpData) : '';
+    const actualLen = cbData || dataStr.length;
     const s = store();
     if (s) {
       const r = s.createKey(hKey, subKey);
       if (r) {
         const REG_SZ = 1;
-        const data = new Uint8Array(cbData + 1);
-        for (let i = 0; i < cbData; i++) data[i] = emu.memory.readU8(lpData + i);
-        data[cbData] = 0;
+        const data = new Uint8Array(actualLen + 1);
+        for (let i = 0; i < actualLen; i++) data[i] = emu.memory.readU8(lpData + i);
+        data[actualLen] = 0;
         s.setValue(r.handle, '', REG_SZ, data);
       }
     }
     return ERROR_SUCCESS;
   }, 5);
 
-  // RegQueryValue(HKEY hKey, LPCSTR lpSubKey, LPSTR lpValue, LONG FAR* lpcbValue)
+  // RegQueryValue(HKEY hKey, LPCSTR lpSubKey, LPSTR lpValue, LONG FAR* lpcbValue) — pascal(long, str, ptr, ptr)
   shell.register('RegQueryValue', 16, () => {
-    const hKey = emu.readArg16DWord(0);
-    const lpSubKey = emu.readArg16FarPtr(4);
+    const [hKeyRaw, lpSubKeyRaw, lpValueRaw, lpcbValueRaw] = emu.readPascalArgs16([4, 4, 4, 4]);
+    const hKey = hKeyRaw;
+    const lpSubKey = emu.resolveFarPtr(lpSubKeyRaw);
     const subKey = lpSubKey ? emu.memory.readCString(lpSubKey) : '';
-    const lpValue = emu.readArg16FarPtr(8);
-    const lpcbValue = emu.readArg16FarPtr(12);
+    const lpValue = emu.resolveFarPtr(lpValueRaw);
+    const lpcbValue = emu.resolveFarPtr(lpcbValueRaw);
     const s = store();
     if (s) {
       let key = hKey;

--- a/src/lib/emu/win16/user/index.ts
+++ b/src/lib/emu/win16/user/index.ts
@@ -81,7 +81,12 @@ export function registerWin16User(emu: Emulator): void {
       const po = clientOrigin(wnd.parent);
       return { x: po.x + (wnd.x || 0), y: po.y + (wnd.y || 0) };
     }
-    // Top-level window (no parent): client origin = window pos + non-client area
+    // Main window: the canvas IS the client area, so origin is (0, 0).
+    // Non-client chrome (title bar, borders, menu) is rendered by the HTML
+    // frame, not on the canvas. GetDC(0) returns the canvas, so screen
+    // coords must equal canvas coords for ClientToScreen/ScreenToClient.
+    if (hwnd === emu.mainWindow) return { x: 0, y: 0 };
+    // Other top-level windows (non-main): include non-client area
     const { bw, captionH, menuH } = getNonClientMetrics(wnd.style, wnd.hMenu !== 0, true);
     return { x: (wnd.x || 0) + bw, y: (wnd.y || 0) + bw + captionH + menuH };
   };

--- a/src/lib/emu/win16/user/menu.ts
+++ b/src/lib/emu/win16/user/menu.ts
@@ -104,6 +104,16 @@ export function registerWin16UserMenu(emu: Emulator, user: Win16Module, h: Win16
   // Ordinal 263: GetMenuItemCount(hMenu) — 2 bytes
   user.register('GetMenuItemCount', 2, () => 0, 263);
 
+  // Ordinal 268: IsMenu(hMenu) — 2 bytes → BOOL
+  user.register('IsMenu', 2, () => {
+    const hMenu = emu.readArg16(0);
+    const obj = emu.handles.get(hMenu);
+    return (obj && typeof obj === 'object' && 'items' in obj) ? 1 : 0;
+  }, 268);
+
+  // Ordinal 271: LookupMenuHandle(hMenu, lpPos_ptr) — 6 bytes (2+4)
+  user.register('LookupMenuHandle', 6, () => 0, 271);
+
   // Ordinal 410: InsertMenu — 12 bytes
   user.register('InsertMenu', 12, () => 1, 410);
 

--- a/src/lib/emu/win16/user/misc.ts
+++ b/src/lib/emu/win16/user/misc.ts
@@ -284,8 +284,8 @@ export function registerWin16UserMisc(emu: Emulator, user: Win16Module, h: Win16
   user.register('GetSystemMetrics', 2, () => {
     const idx = emu.readArg16(0);
     const metrics: Record<number, number> = {
-      0: 640,   // SM_CXSCREEN
-      1: 480,   // SM_CYSCREEN
+      0: emu.screenWidth || 640,   // SM_CXSCREEN
+      1: emu.screenHeight || 480,  // SM_CYSCREEN
       2: 20,    // SM_CXVSCROLL
       3: 20,    // SM_CYVSCROLL
       4: 20,    // SM_CYCAPTION (Win 3.1)

--- a/src/lib/emu/win16/user/misc.ts
+++ b/src/lib/emu/win16/user/misc.ts
@@ -383,6 +383,9 @@ export function registerWin16UserMisc(emu: Emulator, user: Win16Module, h: Win16
   // Ordinal 269: GlobalDeleteAtom — 2 bytes
   user.register('GlobalDeleteAtom', 2, () => 0, 269);
 
+  // Ordinal 270: DCHook(hDC, code, data, lParam) — 12 bytes (2+2+4+4) — internal stub
+  user.register('DCHook', 12, () => 0, 270);
+
   // Ordinal 277: GetDlgCtrlID(hWnd) — 2 bytes
   user.register('GetDlgCtrlID', 2, () => {
     const hWnd = emu.readPascalArgs16([2])[0];

--- a/src/lib/emu/win16/user/window.ts
+++ b/src/lib/emu/win16/user/window.ts
@@ -190,6 +190,8 @@ export function registerWin16UserWindow(emu: Emulator, user: Win16Module, h: Win
     const sw = (w << 16 >> 16);
     const sh = (height << 16 >> 16);
     const CW_USEDEFAULT = -0x8000;
+    const defW = Math.round(emu.screenWidth * 0.75) || 480;
+    const defH = Math.round(emu.screenHeight * 0.75) || 360;
     // MDICLIENT is always visible in practice (container for MDI children)
     const isMDIClient = className.toUpperCase() === 'MDICLIENT';
     const hwnd = emu.handles.alloc('window', {
@@ -199,8 +201,8 @@ export function registerWin16UserWindow(emu: Emulator, user: Win16Module, h: Win
       exStyle: 0,
       x: sx === CW_USEDEFAULT ? 0 : sx,
       y: sy === CW_USEDEFAULT ? 0 : sy,
-      width: sw === CW_USEDEFAULT ? 320 : (sw < 0 ? 0 : sw),
-      height: sh === CW_USEDEFAULT ? 200 : (sh < 0 ? 0 : sh),
+      width: sw === CW_USEDEFAULT ? defW : (sw < 0 ? 0 : sw),
+      height: sh === CW_USEDEFAULT ? defH : (sh < 0 ? 0 : sh),
       hMenu: effectiveMenu,
       parent: hWndParent,
       wndProc: classInfo?.wndProc || 0,
@@ -242,13 +244,26 @@ export function registerWin16UserWindow(emu: Emulator, user: Win16Module, h: Win
     }
 
     if (classInfo?.wndProc) {
+      // Use resolved dimensions in CREATESTRUCT (Windows resolves CW_USEDEFAULT before WM_CREATE)
+      const wndObj = emu.handles.get<WindowInfo>(hwnd);
+      const resolvedW = wndObj?.width ?? (sw < 0 ? 0 : sw);
+      const resolvedH = wndObj?.height ?? (sh < 0 ? 0 : sh);
+      const resolvedX = wndObj?.x ?? (sx < 0 ? 0 : sx);
+      const resolvedY = wndObj?.y ?? (sy < 0 ? 0 : sy);
       const savedSP = emu.cpu.reg[4] & 0xFFFF;
       const cs = buildCreateStruct16(emu, emu.readArg16DWord(0), hInstance, hMenu, hWndParent,
-        height, w, y, x, dwStyle, emu.readArg16DWord(22), emu.readArg16DWord(26), 0);
+        resolvedH, resolvedW, resolvedY, resolvedX, dwStyle, emu.readArg16DWord(22), emu.readArg16DWord(26), 0);
       if (cs) {
         sendCreateMessages16(emu, classInfo.wndProc, hwnd, cs);
       } else {
         emu.callWndProc16(classInfo.wndProc, hwnd, 0x0001, 0, 0);
+      }
+      // Send WM_SIZE after WM_CREATE for the main window (apps position children in WM_SIZE)
+      if (hwnd === emu.mainWindow && emu.canvas) {
+        const WM_SIZE = 0x0005;
+        const cw = emu.canvas.width, ch = emu.canvas.height;
+        const lParam = ((ch & 0xFFFF) << 16) | (cw & 0xFFFF);
+        emu.callWndProc16(classInfo.wndProc, hwnd, WM_SIZE, 0, lParam);
       }
       emu.cpu.reg[4] = (emu.cpu.reg[4] & 0xFFFF0000) | savedSP;
     }
@@ -830,6 +845,8 @@ export function registerWin16UserWindow(emu: Emulator, user: Win16Module, h: Win
     const sw = (w << 16 >> 16);  // signed width
     const sh = (height << 16 >> 16); // signed height
     const CW_USEDEFAULT = -0x8000; // 0x8000 sign-extended = -32768
+    const defWEx = Math.round(emu.screenWidth * 0.75) || 480;
+    const defHEx = Math.round(emu.screenHeight * 0.75) || 360;
     // MDICLIENT is always visible in practice (container for MDI children)
     const isMDIClient = className.toUpperCase() === 'MDICLIENT';
     const hwnd = emu.handles.alloc('window', {
@@ -839,8 +856,8 @@ export function registerWin16UserWindow(emu: Emulator, user: Win16Module, h: Win
       exStyle: dwExStyle,
       x: sx === CW_USEDEFAULT ? 0 : sx,
       y: sy === CW_USEDEFAULT ? 0 : sy,
-      width: sw === CW_USEDEFAULT ? 320 : (sw < 0 ? 0 : sw),
-      height: sh === CW_USEDEFAULT ? 200 : (sh < 0 ? 0 : sh),
+      width: sw === CW_USEDEFAULT ? defWEx : (sw < 0 ? 0 : sw),
+      height: sh === CW_USEDEFAULT ? defHEx : (sh < 0 ? 0 : sh),
       hMenu: effectiveMenu,
       parent: hWndParent,
       wndProc: classInfo?.wndProc || 0,
@@ -882,9 +899,15 @@ export function registerWin16UserWindow(emu: Emulator, user: Win16Module, h: Win
     }
 
     if (classInfo?.wndProc) {
+      // Use resolved dimensions in CREATESTRUCT (Windows resolves CW_USEDEFAULT before WM_CREATE)
+      const wndObjEx = emu.handles.get<WindowInfo>(hwnd);
+      const resolvedWEx = wndObjEx?.width ?? (sw < 0 ? 0 : sw);
+      const resolvedHEx = wndObjEx?.height ?? (sh < 0 ? 0 : sh);
+      const resolvedXEx = wndObjEx?.x ?? (sx < 0 ? 0 : sx);
+      const resolvedYEx = wndObjEx?.y ?? (sy < 0 ? 0 : sy);
       const savedSP = emu.cpu.reg[4] & 0xFFFF;
       const cs = buildCreateStruct16(emu, emu.readArg16DWord(0), hInstance, hMenu, hWndParent,
-        height, w, y, x, dwStyle, emu.readArg16DWord(22), emu.readArg16DWord(26), dwExStyle);
+        resolvedHEx, resolvedWEx, resolvedYEx, resolvedXEx, dwStyle, emu.readArg16DWord(22), emu.readArg16DWord(26), dwExStyle);
       if (cs) {
         sendCreateMessages16(emu, classInfo.wndProc, hwnd, cs);
       } else {

--- a/src/lib/emu/win16/user/window.ts
+++ b/src/lib/emu/win16/user/window.ts
@@ -434,6 +434,9 @@ export function registerWin16UserWindow(emu: Emulator, user: Win16Module, h: Win
     const wnd = emu.handles.get<WindowInfo>(hWnd);
     if (wnd) {
       let mx = (x << 16 >> 16), my = (y << 16 >> 16);
+      // Sign-extend and clamp dimensions (Win16 uses signed int for width/height)
+      const sw = (w << 16 >> 16); const sh = (height << 16 >> 16);
+      const mw = sw < 0 ? 0 : sw; const mh = sh < 0 ? 0 : sh;
       // If parent is a CCS control, adjust Y coordinate only: the x86 COMMCTRL code
       // computes Y positions using GetWindowRect which returns screen coords based on
       // the old CCS position (-100,-100). X is already parent-client-relative.
@@ -448,10 +451,10 @@ export function registerWin16UserWindow(emu: Emulator, user: Win16Module, h: Win
         }
       }
       wnd.x = mx; wnd.y = my;
-      const sizeChanged = wnd.width !== w || wnd.height !== height;
-      wnd.width = w; wnd.height = height;
+      const sizeChanged = wnd.width !== mw || wnd.height !== mh;
+      wnd.width = mw; wnd.height = mh;
       if (sizeChanged) {
-        const { cw, ch } = getClientSize(wnd.style, wnd.hMenu !== 0, w, height, true);
+        const { cw, ch } = getClientSize(wnd.style, wnd.hMenu !== 0, mw, mh, true);
         if (hWnd === emu.mainWindow) {
           emu.setupCanvasSize(cw, ch);
           emu.onWindowChange?.(wnd);

--- a/src/lib/emu/win16/user/window.ts
+++ b/src/lib/emu/win16/user/window.ts
@@ -229,9 +229,16 @@ export function registerWin16UserWindow(emu: Emulator, user: Win16Module, h: Win
       }
     }
 
-    if (!emu.mainWindow && hWndParent === 0) {
-      const wnd = emu.handles.get<WindowInfo>(hwnd);
-      if (wnd) emu.promoteToMainWindow(hwnd, wnd);
+    // Promote to mainWindow: skip WS_POPUP and re-promote if a window with
+    // WS_CAPTION is created after a bare WS_OVERLAPPED (hidden OLE/DDE windows)
+    if (hWndParent === 0 && !(dwStyle & 0x80000000)) { // not WS_POPUP
+      const currentMain = emu.mainWindow ? emu.handles.get<WindowInfo>(emu.mainWindow) : null;
+      const hasCaption = !!(dwStyle & 0x00C00000); // WS_CAPTION
+      const currentHasCaption = currentMain ? !!(currentMain.style & 0x00C00000) : false;
+      if (!emu.mainWindow || (!currentHasCaption && hasCaption)) {
+        const wnd = emu.handles.get<WindowInfo>(hwnd);
+        if (wnd) emu.promoteToMainWindow(hwnd, wnd);
+      }
     }
 
     if (classInfo?.wndProc) {
@@ -862,9 +869,16 @@ export function registerWin16UserWindow(emu: Emulator, user: Win16Module, h: Win
       }
     }
 
-    if (!emu.mainWindow && hWndParent === 0) {
-      const wnd = emu.handles.get<WindowInfo>(hwnd);
-      if (wnd) emu.promoteToMainWindow(hwnd, wnd);
+    // Promote to mainWindow: skip WS_POPUP and re-promote if a window with
+    // WS_CAPTION is created after a bare WS_OVERLAPPED (hidden OLE/DDE windows)
+    if (hWndParent === 0 && !(dwStyle & 0x80000000)) { // not WS_POPUP
+      const currentMain = emu.mainWindow ? emu.handles.get<WindowInfo>(emu.mainWindow) : null;
+      const hasCaption = !!(dwStyle & 0x00C00000); // WS_CAPTION
+      const currentHasCaption = currentMain ? !!(currentMain.style & 0x00C00000) : false;
+      if (!emu.mainWindow || (!currentHasCaption && hasCaption)) {
+        const wnd = emu.handles.get<WindowInfo>(hwnd);
+        if (wnd) emu.promoteToMainWindow(hwnd, wnd);
+      }
     }
 
     if (classInfo?.wndProc) {

--- a/src/lib/emu/win32/gdi32/bitmap.ts
+++ b/src/lib/emu/win32/gdi32/bitmap.ts
@@ -8,6 +8,7 @@ import type { DCInfo } from './types';
 import type { WindowInfo } from '../user32/types';
 import { colorToCSS, disableSmoothing } from './_helpers';
 import { decodeDib } from '../../../pe/decode-dib';
+import { dcPutImageData } from '../../emu-window';
 import { resolvePaletteColors } from './palette';
 import { emuCompleteThunk } from '../../emu-exec';
 
@@ -264,7 +265,7 @@ export function registerBitmap(emu: Emulator): void {
       }
     }
 
-    dc.ctx.putImageData(imgData, xDest, yDest);
+    dcPutImageData(dc, imgData, xDest, yDest);
     emu.syncDCToCanvas(hdc);
     return drawH;
   });

--- a/src/lib/emu/win32/gdi32/draw.ts
+++ b/src/lib/emu/win32/gdi32/draw.ts
@@ -100,6 +100,9 @@ export function registerDraw(emu: Emulator): void {
       let pr = 0, pg = 0, pb = 0;
       if (pen) { pr = pen.color & 0xFF; pg = (pen.color >> 8) & 0xFF; pb = (pen.color >> 16) & 0xFF; }
       const cw = dc.canvas.width || 1, ch = dc.canvas.height || 1;
+      // getImageData ignores canvas transforms — apply offset manually
+      const tf = dc.ctx.getTransform();
+      const oX = Math.round(tf.e), oY = Math.round(tf.f);
       const imgData = dc.ctx.getImageData(0, 0, cw, ch);
       const d = imgData.data;
       let x0 = dc.penPosX, y0 = dc.penPosY, x1 = x, y1 = y;
@@ -107,8 +110,9 @@ export function registerDraw(emu: Emulator): void {
       const sx = x0 < x1 ? 1 : -1, sy = y0 < y1 ? 1 : -1;
       let err = dx - dy;
       while (true) {
-        if (x0 >= 0 && x0 < cw && y0 >= 0 && y0 < ch) {
-          const off = (y0 * cw + x0) * 4;
+        const cx = x0 + oX, cy = y0 + oY;
+        if (cx >= 0 && cx < cw && cy >= 0 && cy < ch) {
+          const off = (cy * cw + cx) * 4;
           const dr = d[off], dg = d[off+1], db = d[off+2];
           let rr: number, rg: number, rb: number;
           switch (rop2) {
@@ -221,13 +225,17 @@ export function registerDraw(emu: Emulator): void {
       }
     }
 
+    // getImageData ignores canvas transforms — apply offset manually
+    const tf = dc.ctx.getTransform();
+    const cx = Math.round(tf.e + x * tf.a);
+    const cy = Math.round(tf.f + y * tf.d);
     // Bounds check to avoid OOM from getImageData with large/negative coordinates
-    if (x < 0 || y < 0) return 0xFFFFFFFF;
+    if (cx < 0 || cy < 0) return 0xFFFFFFFF;
     const canvas = dc.ctx.canvas;
-    if (canvas && (x >= canvas.width || y >= canvas.height)) return 0xFFFFFFFF;
+    if (canvas && (cx >= canvas.width || cy >= canvas.height)) return 0xFFFFFFFF;
 
     try {
-      const imgData = dc.ctx.getImageData(x, y, 1, 1);
+      const imgData = dc.ctx.getImageData(cx, cy, 1, 1);
       const [r, g, b] = imgData.data;
       return r | (g << 8) | (b << 16);
     } catch {
@@ -271,10 +279,13 @@ export function registerDraw(emu: Emulator): void {
       const r = penColor & 0xFF, g = (penColor >> 8) & 0xFF, b = (penColor >> 16) & 0xFF;
       const cw = (dc.canvas as OffscreenCanvas).width || 640;
       const ch = (dc.canvas as OffscreenCanvas).height || 480;
+      // getImageData ignores canvas transforms — apply offset manually
+      const tf = dc.ctx.getTransform();
+      const oX = Math.round(tf.e), oY = Math.round(tf.f);
       const imgData = dc.ctx.getImageData(0, 0, cw, ch);
       const data = imgData.data;
       const setPixel = (x: number, y: number) => {
-        x = Math.round(x); y = Math.round(y);
+        x = Math.round(x) + oX; y = Math.round(y) + oY;
         if (x < 0 || x >= cw || y < 0 || y >= ch) return;
         const idx = (y * cw + x) * 4;
         data[idx] = r; data[idx + 1] = g; data[idx + 2] = b; data[idx + 3] = 255;
@@ -918,7 +929,11 @@ function floodFillImpl(
   const canvas = dc.ctx.canvas || dc.canvas;
   if (!canvas) return;
   const w = canvas.width, h = canvas.height;
-  if (w <= 0 || h <= 0 || x < 0 || x >= w || y < 0 || y >= h) return;
+  // getImageData ignores canvas transforms — apply offset manually
+  const tf = dc.ctx.getTransform();
+  const oX = Math.round(tf.e), oY = Math.round(tf.f);
+  const sx = x + oX, sy = y + oY;
+  if (w <= 0 || h <= 0 || sx < 0 || sx >= w || sy < 0 || sy >= h) return;
 
   const imgData = dc.ctx.getImageData(0, 0, w, h);
   const px = imgData.data;
@@ -952,10 +967,10 @@ function floodFillImpl(
     }
   };
 
-  if (!shouldFill(x, y)) return;
+  if (!shouldFill(sx, sy)) return;
 
   // Scanline flood fill with stack
-  const stack: number[] = [x, y];
+  const stack: number[] = [sx, sy];
   const MAX_PIXELS = w * h;
   let filled = 0;
 

--- a/src/lib/emu/x86/cpu.ts
+++ b/src/lib/emu/x86/cpu.ts
@@ -78,6 +78,7 @@ export class CPU {
   es = 0; // extra segment selector
   ss = 0; // stack segment selector
   segBases: Map<number, number> = new Map<number, number>(); // selector → linear base address
+  segLimits: Map<number, number> = new Map<number, number>(); // selector → segment limit
   _addrSize16 = false; // true when current instruction uses 16-bit addressing
   _inhibitTF = false;  // true after INT/IRET/MOV SS/POP SS (suppresses TF trap)
   _inhibitIRQ = false; // true after MOV SS/POP SS (suppresses HW IRQ for 1 instruction)

--- a/src/lib/emu/x86/ops-0f.ts
+++ b/src/lib/emu/x86/ops-0f.ts
@@ -211,10 +211,48 @@ export function exec0F(
       break;
     }
 
-    // LAR r, r/m16 — Load Access Rights (always fails in real mode: clear ZF)
-    case 0x02: {
+    case 0x02: { // LAR r16/r32, r/m16 — load access rights
       const d = cpu.decodeModRM(opSize);
-      cpu.setFlags(cpu.getFlags() & ~ZF);
+      const sel = d.val & 0xFFFF;
+      if (cpu.segBases.has(sel) || cpu.segBases.has(sel >>> 3)) {
+        // Valid selector — return data segment access rights, set ZF
+        const rights = opSize === 16 ? 0xF300 : 0x00CF9300;
+        if (opSize === 16) {
+          cpu.reg[d.regField] = (cpu.reg[d.regField] & 0xFFFF0000) | (rights & 0xFFFF);
+        } else {
+          cpu.reg[d.regField] = rights;
+        }
+        cpu.setFlags(cpu.getFlags() | ZF);
+      } else {
+        cpu.setFlags(cpu.getFlags() & ~ZF);
+      }
+      break;
+    }
+
+    case 0x03: { // LSL r16/r32, r/m16 — load segment limit
+      const d = cpu.decodeModRM(opSize);
+      const sel = d.val & 0xFFFF;
+      const canonical = sel >>> 3;
+      const limit = cpu.segLimits.get(sel) ?? cpu.segLimits.get(canonical);
+      if (limit !== undefined) {
+        if (opSize === 16) {
+          cpu.reg[d.regField] = (cpu.reg[d.regField] & 0xFFFF0000) | (limit & 0xFFFF);
+        } else {
+          cpu.reg[d.regField] = limit;
+        }
+        cpu.setFlags(cpu.getFlags() | ZF);
+      } else if (cpu.segBases.has(sel) || cpu.segBases.has(canonical)) {
+        // Known selector without explicit limit — default to 64KB
+        const defLimit = 0xFFFF;
+        if (opSize === 16) {
+          cpu.reg[d.regField] = (cpu.reg[d.regField] & 0xFFFF0000) | defLimit;
+        } else {
+          cpu.reg[d.regField] = defLimit;
+        }
+        cpu.setFlags(cpu.getFlags() | ZF);
+      } else {
+        cpu.setFlags(cpu.getFlags() & ~ZF);
+      }
       break;
     }
 

--- a/src/lib/registry-store.ts
+++ b/src/lib/registry-store.ts
@@ -23,6 +23,8 @@ const ROOT_HANDLES = new Map<number, string>([
   [HKEY_USERS, 'hkey_users'],
   [HKEY_CURRENT_CONFIG, 'hkey_current_config'],
   [HKEY_DYN_DATA, 'hkey_dyn_data'],
+  // Win16 uses small integer handles for root keys (HKEY_CLASSES_ROOT = 1)
+  [1, 'hkey_classes_root'],
 ]);
 
 const REG_CREATED_NEW_KEY = 1;

--- a/tests/test-pbrush.mjs
+++ b/tests/test-pbrush.mjs
@@ -88,6 +88,40 @@ if (emu.waitingForMessage) {
   const t01b1 = emu.thunkToApi.get(0xF01B1);
   console.log(`[TEST] Thunk@0xF01B1: ${t01b1 ? `${t01b1.dll}:${t01b1.name} (${t01b1.displayName})` : 'NOT FOUND'}`);
 
+  // Check message queue
+  console.log(`[TEST] Message queue length: ${emu._messageQueue?.length || 0}`);
+  if (emu._messageQueue) {
+    for (const msg of emu._messageQueue) {
+      console.log(`  queued: hwnd=0x${msg.hwnd.toString(16)} msg=0x${msg.message.toString(16)} wP=${msg.wParam} lP=0x${msg.lParam.toString(16)}`);
+    }
+  }
+  // Process queued messages (WM_SIZE etc.) before dumping children
+  emu.traceApi = true;
+  emu.waitingForMessage = false;
+  let extraTicks = 0;
+  while (!emu.waitingForMessage && !emu.halted && extraTicks < 50) {
+    emu.tick();
+    extraTicks++;
+  }
+  emu.traceApi = false;
+  console.log(`[TEST] Processed ${extraTicks} extra ticks, halted=${emu.halted}`);
+
+  // Dump child windows
+  if (mainWnd?.childList) {
+    for (const ch of mainWnd.childList) {
+      const w = emu.handles.get(ch);
+      if (!w) continue;
+      console.log(`  child 0x${ch.toString(16)} class="${w.classInfo?.className}" vis=${w.visible} pos=(${w.x},${w.y}) size=${w.width}x${w.height} style=0x${(w.style||0).toString(16)} wndProc=0x${(w.wndProc||0).toString(16)}`);
+      if (w.childList) {
+        for (const gc of w.childList) {
+          const gw = emu.handles.get(gc);
+          if (!gw) continue;
+          console.log(`    grandchild 0x${gc.toString(16)} class="${gw.classInfo?.className}" vis=${gw.visible} pos=(${gw.x},${gw.y}) size=${gw.width}x${gw.height}`);
+        }
+      }
+    }
+  }
+
   // Simulate menu open (WM_INITMENU + WM_INITMENUPOPUP) like EmulatorView.tsx does
   const WM_INITMENU = 0x0116;
   const WM_INITMENUPOPUP = 0x0117;

--- a/tests/test-pbrush.mjs
+++ b/tests/test-pbrush.mjs
@@ -1,0 +1,86 @@
+import { readFileSync } from 'fs';
+import { Emulator } from '../src/lib/emu/emulator.ts';
+import { parsePE } from '../src/lib/pe/index.ts';
+import { RegistryStore } from '../src/lib/registry-store.ts';
+
+// Mock Canvas/OffscreenCanvas for headless Node.js
+const noop = () => {};
+const mockCtx = {
+  fillRect: noop, clearRect: noop, strokeRect: noop,
+  fillText: noop, strokeText: noop, measureText: () => ({ width: 8 }),
+  drawImage: noop, putImageData: noop, getImageData: () => ({ data: new Uint8ClampedArray(4) }),
+  createImageData: (w, h) => ({ data: new Uint8ClampedArray(w * h * 4), width: w, height: h }),
+  save: noop, restore: noop, translate: noop, scale: noop, rotate: noop,
+  setTransform: noop, resetTransform: noop, transform: noop,
+  beginPath: noop, closePath: noop, moveTo: noop, lineTo: noop,
+  arc: noop, arcTo: noop, rect: noop, ellipse: noop,
+  fill: noop, stroke: noop, clip: noop,
+  createLinearGradient: () => ({ addColorStop: noop }),
+  createRadialGradient: () => ({ addColorStop: noop }),
+  createPattern: () => null,
+  font: '', textAlign: 'left', textBaseline: 'top',
+  fillStyle: '', strokeStyle: '', lineWidth: 1, lineCap: 'butt', lineJoin: 'miter',
+  globalAlpha: 1, globalCompositeOperation: 'source-over',
+  imageSmoothingEnabled: true, shadowBlur: 0, shadowColor: 'transparent',
+  canvas: null,
+};
+const mockCanvas = {
+  width: 640, height: 480,
+  getContext: () => mockCtx,
+  toDataURL: () => 'data:image/png;base64,',
+  addEventListener: noop,
+  removeEventListener: noop,
+  style: { cursor: 'default' },
+  parentElement: { style: { cursor: 'default' } },
+};
+mockCtx.canvas = mockCanvas;
+
+globalThis.document = { createElement: () => mockCanvas, title: '' };
+globalThis.OffscreenCanvas = class {
+  constructor(w, h) { this.width = w; this.height = h; }
+  getContext() { return { ...mockCtx, canvas: this }; }
+};
+globalThis.requestAnimationFrame = (cb) => setTimeout(cb, 0);
+globalThis.Image = class { set src(_) {} };
+globalThis.URL = { createObjectURL: () => 'blob:mock', revokeObjectURL: noop };
+globalThis.Blob = class { constructor() {} };
+
+// Helper: read file into proper ArrayBuffer
+function readToArrayBuffer(path) {
+  const b = readFileSync(path);
+  const ab = new ArrayBuffer(b.byteLength);
+  new Uint8Array(ab).set(b);
+  return ab;
+}
+
+// Load PBRUSH.EXE + companion DLLs
+const realArrayBuffer = readToArrayBuffer('H:/WINDOWS/PBRUSH.EXE');
+const peInfo = parsePE(realArrayBuffer);
+
+const emu = new Emulator();
+emu.screenWidth = 800;
+emu.screenHeight = 600;
+emu.registryStore = new RegistryStore();
+// Load companion DLLs that PBRUSH imports
+emu.additionalFiles.set('PBRUSH.DLL', readToArrayBuffer('H:/WINDOWS/PBRUSH.DLL'));
+emu.additionalFiles.set('OLESVR.DLL', readToArrayBuffer('H:/WINDOWS/SYSTEM/OLESVR.DLL'));
+await emu.load(realArrayBuffer, peInfo, mockCanvas);
+emu.run();
+
+// Tick until message loop reached or MessageBox shown
+const MAX_TICKS = 500;
+let ticks = 0;
+while (!emu.waitingForMessage && !emu.halted && ticks < MAX_TICKS) {
+  emu.tick();
+  ticks++;
+}
+
+if (emu.waitingForMessage) {
+  const mainWnd = emu.handles.get(emu.mainWindow);
+  console.log(`[TEST] SUCCESS: Reached message loop after ${ticks} ticks`);
+  console.log(`[TEST] MainWindow: 0x${emu.mainWindow.toString(16)} class="${mainWnd?.classInfo?.className}" title="${mainWnd?.title}" size=${mainWnd?.width}x${mainWnd?.height} style=0x${(mainWnd?.style||0).toString(16)}`);
+} else if (emu.halted) {
+  console.error(`[TEST] HALTED after ${ticks} ticks: ${emu.cpu.haltReason}`);
+} else {
+  console.error(`[TEST] TIMEOUT after ${MAX_TICKS} ticks`);
+}

--- a/tests/test-pbrush.mjs
+++ b/tests/test-pbrush.mjs
@@ -79,6 +79,34 @@ if (emu.waitingForMessage) {
   const mainWnd = emu.handles.get(emu.mainWindow);
   console.log(`[TEST] SUCCESS: Reached message loop after ${ticks} ticks`);
   console.log(`[TEST] MainWindow: 0x${emu.mainWindow.toString(16)} class="${mainWnd?.classInfo?.className}" title="${mainWnd?.title}" size=${mainWnd?.width}x${mainWnd?.height} style=0x${(mainWnd?.style||0).toString(16)}`);
+
+  // Dump thunk map to find what's at key addresses
+  const thunkEnd = Math.max(...emu.thunkToApi.keys());
+  console.log(`[TEST] Thunk range: 0x${Math.min(...emu.thunkToApi.keys()).toString(16)} - 0x${thunkEnd.toString(16)} (${emu.thunkToApi.size} entries)`);
+
+  // Check what's at 0xF01B1
+  const t01b1 = emu.thunkToApi.get(0xF01B1);
+  console.log(`[TEST] Thunk@0xF01B1: ${t01b1 ? `${t01b1.dll}:${t01b1.name} (${t01b1.displayName})` : 'NOT FOUND'}`);
+
+  // Simulate menu open (WM_INITMENU + WM_INITMENUPOPUP) like EmulatorView.tsx does
+  const WM_INITMENU = 0x0116;
+  const WM_INITMENUPOPUP = 0x0117;
+  const hMenu = mainWnd.hMenu || 0;
+  console.log(`\n[TEST] Simulating menu open (hMenu=0x${hMenu.toString(16)}, wndProc=0x${mainWnd.wndProc.toString(16)})...`);
+  emu.traceApi = true;
+  emu.waitingForMessage = false;
+  emu.callWndProc16(mainWnd.wndProc, emu.mainWindow, WM_INITMENU, hMenu, 0);
+  console.log(`[TEST] WM_INITMENU done, halted=${emu.halted}`);
+  if (!emu.halted) {
+    emu.callWndProc16(mainWnd.wndProc, emu.mainWindow, WM_INITMENUPOPUP, 0, 0);
+    console.log(`[TEST] WM_INITMENUPOPUP done, halted=${emu.halted}`);
+  }
+  if (emu.halted) {
+    console.error(`[TEST] HALTED: ${emu.cpu.haltReason}`);
+    console.error(emu.diagThunkDump());
+  } else {
+    console.log(`[TEST] Menu open handled OK`);
+  }
 } else if (emu.halted) {
   console.error(`[TEST] HALTED after ${ticks} ticks: ${emu.cpu.haltReason}`);
 } else {

--- a/tests/test-pbrush.mjs
+++ b/tests/test-pbrush.mjs
@@ -2,6 +2,7 @@ import { readFileSync } from 'fs';
 import { Emulator } from '../src/lib/emu/emulator.ts';
 import { parsePE } from '../src/lib/pe/index.ts';
 import { RegistryStore } from '../src/lib/registry-store.ts';
+import { ProfileStore } from '../src/lib/profile-store.ts';
 
 // Mock Canvas/OffscreenCanvas for headless Node.js
 const noop = () => {};
@@ -61,6 +62,7 @@ const emu = new Emulator();
 emu.screenWidth = 800;
 emu.screenHeight = 600;
 emu.registryStore = new RegistryStore();
+emu.profileStore = new ProfileStore();
 // Load companion DLLs that PBRUSH imports
 emu.additionalFiles.set('PBRUSH.DLL', readToArrayBuffer('H:/WINDOWS/PBRUSH.DLL'));
 emu.additionalFiles.set('OLESVR.DLL', readToArrayBuffer('H:/WINDOWS/SYSTEM/OLESVR.DLL'));

--- a/tests/test-pbrush.mjs
+++ b/tests/test-pbrush.mjs
@@ -122,6 +122,33 @@ if (emu.waitingForMessage) {
     }
   }
 
+  // Simulate clicking on a tool (pbTool at pos 2,2 size 57x278)
+  console.log(`\n[TEST] Simulating click on pbTool (30, 50)...`);
+  const WM_LBUTTONDOWN = 0x0201;
+  const WM_LBUTTONUP = 0x0202;
+  const pbToolHwnd = mainWnd.childList[1]; // pbTool
+  console.log(`[TEST] pbTool hwnd=0x${pbToolHwnd.toString(16)}`);
+  emu.postMessage(pbToolHwnd, WM_LBUTTONDOWN, 1, (50 << 16) | 28);
+  emu.postMessage(pbToolHwnd, WM_LBUTTONUP, 0, (50 << 16) | 28);
+  emu.waitingForMessage = false;
+  let clickTicks = 0;
+  while (!emu.waitingForMessage && !emu.halted && clickTicks < 50) {
+    emu.tick();
+    clickTicks++;
+  }
+  console.log(`[TEST] After tool click: halted=${emu.halted} ticks=${clickTicks} capturedWindow=0x${(emu.capturedWindow||0).toString(16)} reason=${emu.cpu.haltReason || 'none'}`);
+  // Process more ticks to handle WM_LBUTTONUP
+  emu.waitingForMessage = false;
+  let clickTicks2 = 0;
+  while (!emu.waitingForMessage && !emu.halted && clickTicks2 < 50) {
+    emu.tick();
+    clickTicks2++;
+  }
+  console.log(`[TEST] After LBUTTONUP dispatch: halted=${emu.halted} ticks=${clickTicks2} capturedWindow=0x${(emu.capturedWindow||0).toString(16)}`);
+  if (emu.halted) {
+    console.error(emu.diagThunkDump());
+  }
+
   // Simulate menu open (WM_INITMENU + WM_INITMENUPOPUP) like EmulatorView.tsx does
   const WM_INITMENU = 0x0116;
   const WM_INITMENUPOPUP = 0x0117;


### PR DESCRIPTION

  ## Summary

  - Add initial support for PBRUSH.EXE (Windows 3.1 Paintbrush): startup, window display, basic tool interaction
  - Fix Win16 GDI rendering pipeline: transform-aware getImageData/putImageData, monochrome SetBitmapBits, DSPDxax color
   patterns
  - Fix several Win16 core issues: WILD EIP on menu open, CW_USEDEFAULT sizing, ClientToScreen offsets, mouse capture
  auto-release

  ## Known issues

  - Window resize erases the canvas content
  - Not all tools and features have been tested

  ## Details

  **New instructions & loader fixes:**
  - Implement LSL (0F 03), fix LAR (0F 02) for valid selectors
  - Populate segment limits from NE/DLL segments for LSL lookups

  **Win16 API fixes:**
  - Fix PASCAL parameter ordering in shell registry functions
  - PrintDlg returns allocated DEVMODE16 instead of failing
  - GlobalLock falls back to segBases for DLL-allocated selectors
  - GetDeviceCaps/GetSystemMetrics use actual screen dimensions
  - CW_USEDEFAULT uses 75% screen size, CREATESTRUCT passes resolved dims
  - MoveWindow clamps negative dimensions (signed int16)

  **GDI rendering:**
  - DC attribute preservation for child windows (reuse DC instead of recreating)
  - Transform-aware getImageData/dcPutImageData helpers (respects clip regions)
  - SetBitmapBits handles 1bpp monochrome bitmaps correctly
  - DSPDxax ROP distinguishes mono vs color pattern brushes

  **Window management:**
  - Save/restore CS:EIP in callWndProc16 (fixes WILD EIP on menu dispatch)
  - ClientToScreen returns (0,0) for main window (canvas IS the client area)
  - Auto-release mouse capture when cursor leaves window with no buttons pressed
  - Pre-populate WIN.INI [Paintbrush] defaults

  ## Test plan
  - [x] Run `timeout 2 npx tsx tests/test-pbrush.mjs` — reaches message loop
  - [x] Load PBRUSH.EXE in browser — window displays, basic tool clicks work
  - [x] Verify existing Win16 apps (WINFILE, CALC) still work
