### PR TITLE
Add mouse support for DOS graphics programs

### DIFF
--- a/src/components/ConsoleView.tsx
+++ b/src/components/ConsoleView.tsx
@@ -2,7 +2,7 @@ import { useRef, useEffect, useCallback, useState, useLayoutEffect } from 'preac
 import { type Emulator, isFullwidth } from '../lib/emu/emulator';
 import { cp437ToChar } from '../lib/emu/cp437';
 import { loadDosSettings } from '../lib/dos-settings';
-import { injectDosMouseEvent } from '../lib/emu/dos/mouse';
+import { injectDosMouseEvent, drawGfxMouseCursor } from '../lib/emu/dos/mouse';
 
 // Default Windows console 16-color palette (fallback for Win32 programs)
 const DEFAULT_CONSOLE_COLORS = [
@@ -223,7 +223,10 @@ export function ConsoleView({ emu, focused = true }: ConsoleViewProps) {
       const fb = emu.vga.framebuffer;
       if (canvas && fb) {
         const ctx = canvas.getContext('2d');
-        if (ctx) ctx.putImageData(fb, 0, 0);
+        if (ctx) {
+          ctx.putImageData(fb, 0, 0);
+          drawGfxMouseCursor(ctx, emu);
+        }
       } else {
         // Canvas not mounted yet (mode just switched) — trigger re-render
         render();
@@ -705,6 +708,7 @@ export function ConsoleView({ emu, focused = true }: ConsoleViewProps) {
   const fb = emu.vga.framebuffer;
   const gfxWidth = fb ? fb.width : emu.vga.currentMode.width;
   const gfxHeight = fb ? fb.height : emu.vga.currentMode.height;
+  const dosMouseVisible = isGfx && emu.dosMouse.installed && emu.dosMouse.cursorVisible >= 0;
 
   return (
     <div
@@ -724,6 +728,7 @@ export function ConsoleView({ emu, focused = true }: ConsoleViewProps) {
             width: '640px',
             height: '480px',
             imageRendering: 'pixelated',
+            cursor: dosMouseVisible ? 'none' : 'default',
           }}
         />
       ) : useCanvas ? (

--- a/src/lib/emu/dos/mouse.ts
+++ b/src/lib/emu/dos/mouse.ts
@@ -12,6 +12,19 @@ const MOUSE_EVENT_RUP      = 0x10;
 const MOUSE_EVENT_MDOWN    = 0x20;
 const MOUSE_EVENT_MUP      = 0x40;
 
+// Default graphics cursor: 16x16 arrow (AND mask, then XOR mask)
+// Each row is a 16-bit value, MSB = leftmost pixel
+const DEFAULT_CURSOR_AND: Uint16Array = new Uint16Array([
+  0x3FFF, 0x1FFF, 0x0FFF, 0x07FF, 0x03FF, 0x01FF, 0x00FF, 0x007F,
+  0x003F, 0x001F, 0x01FF, 0x10FF, 0x30FF, 0xF87F, 0xF87F, 0xFC3F,
+]);
+const DEFAULT_CURSOR_XOR: Uint16Array = new Uint16Array([
+  0x0000, 0x4000, 0x6000, 0x7000, 0x7800, 0x7C00, 0x7E00, 0x7F00,
+  0x7F80, 0x7FC0, 0x7C00, 0x4600, 0x0600, 0x0300, 0x0300, 0x0000,
+]);
+const DEFAULT_CURSOR_HOTX = 0;
+const DEFAULT_CURSOR_HOTY = 0;
+
 /** DOS mouse driver state, stored on Emulator as `dosMouse` */
 export interface DosMouseState {
   installed: boolean;
@@ -46,6 +59,11 @@ export interface DosMouseState {
   // Last browser mapped position for delta computation (-1 = uninitialized)
   lastBrowserX: number;
   lastBrowserY: number;
+  // Graphics cursor shape (16x16 AND/XOR masks + hotspot)
+  cursorAnd: Uint16Array;
+  cursorXor: Uint16Array;
+  cursorHotX: number;
+  cursorHotY: number;
 }
 
 export function createDosMouseState(): DosMouseState {
@@ -68,6 +86,10 @@ export function createDosMouseState(): DosMouseState {
     sensX: 8, sensY: 16,
     doubleThreshold: 64,
     lastBrowserX: -1, lastBrowserY: -1,
+    cursorAnd: Uint16Array.from(DEFAULT_CURSOR_AND),
+    cursorXor: Uint16Array.from(DEFAULT_CURSOR_XOR),
+    cursorHotX: DEFAULT_CURSOR_HOTX,
+    cursorHotY: DEFAULT_CURSOR_HOTY,
   };
 }
 
@@ -178,9 +200,14 @@ export function handleInt33(cpu: CPU, emu: Emulator): boolean {
       m.releaseX = [0, 0, 0]; m.releaseY = [0, 0, 0];
       m.sensX = 8; m.sensY = 16; m.doubleThreshold = 64;
       m.lastBrowserX = -1; m.lastBrowserY = -1;
+      m.cursorAnd = Uint16Array.from(DEFAULT_CURSOR_AND);
+      m.cursorXor = Uint16Array.from(DEFAULT_CURSOR_XOR);
+      m.cursorHotX = DEFAULT_CURSOR_HOTX;
+      m.cursorHotY = DEFAULT_CURSOR_HOTY;
       m.installed = true;
       cpu.setReg16(EAX, 0xFFFF); // mouse installed
       cpu.setReg16(EBX, 3);       // 3 buttons
+      console.log(`[INT 33h] AX=0 reset mouse, maxY=${m.maxY} isGfx=${emu.isGraphicsMode} mode=0x${emu.videoMode.toString(16)}`);
       return true;
     }
 
@@ -235,8 +262,17 @@ export function handleInt33(cpu: CPU, emu: Emulator): boolean {
       m.y = Math.max(m.minY, Math.min(m.maxY, m.y));
       return true;
 
-    case 0x0009: // Set graphics cursor shape (stub — no hardware cursor)
+    case 0x0009: { // Set graphics cursor shape
+      m.cursorHotX = cpu.getReg16(EBX); // BX = hot spot column
+      m.cursorHotY = cpu.getReg16(ECX); // CX = hot spot row
+      // ES:DX → pointer to 32 words: 16 AND mask rows, then 16 XOR mask rows
+      const maskAddr = cpu.segBase(cpu.es) + cpu.getReg16(EDX);
+      for (let i = 0; i < 16; i++) {
+        m.cursorAnd[i] = emu.memory.readU16(maskAddr + i * 2);
+        m.cursorXor[i] = emu.memory.readU16(maskAddr + 32 + i * 2);
+      }
       return true;
+    }
 
     case 0x000A: // Set text cursor type (stub)
       return true;
@@ -252,6 +288,7 @@ export function handleInt33(cpu: CPU, emu: Emulator): boolean {
       m.callbackMask = cpu.getReg16(ECX);
       m.callbackSeg = cpu.es;
       m.callbackOff = cpu.getReg16(EDX);
+      console.log(`[INT 33h] AX=0C set callback mask=0x${m.callbackMask.toString(16)} addr=${m.callbackSeg.toString(16)}:${m.callbackOff.toString(16)}`);
       return true;
     }
 
@@ -323,6 +360,84 @@ export function handleInt33(cpu: CPU, emu: Emulator): boolean {
 }
 
 /**
+ * Update mouse coordinate range when the video mode changes.
+ * Real DOS mouse drivers hook INT 10h and auto-adjust.
+ */
+export function updateMouseRangeForMode(emu: Emulator): void {
+  const m = emu.dosMouse;
+  if (!m.installed) return;
+  const prevMaxY = m.maxY;
+  m.maxX = 639;
+  m.maxY = emu.isGraphicsMode ? (emu.videoMode === 0x13 ? 199 : 479) : 199;
+  // Clamp current position to new range
+  m.x = Math.max(m.minX, Math.min(m.maxX, m.x));
+  if (prevMaxY !== m.maxY) {
+    m.y = Math.max(m.minY, Math.min(m.maxY, m.y));
+  }
+}
+
+/**
+ * Draw the graphics-mode mouse cursor onto a canvas context.
+ * Called after the framebuffer is rendered so the cursor overlays the image
+ * without modifying the actual VRAM framebuffer data.
+ *
+ * @param ctx - Canvas 2D context at native resolution (e.g. 320x200)
+ * @param emu - Emulator instance
+ */
+export function drawGfxMouseCursor(ctx: CanvasRenderingContext2D, emu: Emulator): void {
+  const m = emu.dosMouse;
+  if (!m.installed || m.cursorVisible < 0 || !emu.isGraphicsMode) return;
+
+  const fb = emu.vga.framebuffer;
+  if (!fb) return;
+  const screenW = fb.width;
+  const screenH = fb.height;
+
+  // Convert virtual mouse coordinates to pixel coordinates
+  const pixelX = Math.round(m.x * (screenW - 1) / m.maxX) - m.cursorHotX;
+  const pixelY = Math.round(m.y * (screenH - 1) / m.maxY) - m.cursorHotY;
+
+  // Clip cursor region to screen bounds
+  const x0 = Math.max(0, pixelX);
+  const y0 = Math.max(0, pixelY);
+  const x1 = Math.min(screenW, pixelX + 16);
+  const y1 = Math.min(screenH, pixelY + 16);
+  if (x0 >= x1 || y0 >= y1) return;
+
+  // Read existing pixels under cursor area
+  const region = ctx.getImageData(x0, y0, x1 - x0, y1 - y0);
+  const data = region.data;
+
+  for (let cy = y0; cy < y1; cy++) {
+    const row = cy - pixelY;
+    const andRow = m.cursorAnd[row];
+    const xorRow = m.cursorXor[row];
+    for (let cx = x0; cx < x1; cx++) {
+      const col = cx - pixelX;
+      const bit = 0x8000 >>> col;
+      const andBit = andRow & bit;
+      const xorBit = xorRow & bit;
+      const idx = ((cy - y0) * (x1 - x0) + (cx - x0)) * 4;
+      if (!andBit && !xorBit) {
+        // Black (cursor outline)
+        data[idx] = 0; data[idx + 1] = 0; data[idx + 2] = 0; data[idx + 3] = 255;
+      } else if (!andBit && xorBit) {
+        // White (cursor fill)
+        data[idx] = 255; data[idx + 1] = 255; data[idx + 2] = 255; data[idx + 3] = 255;
+      } else if (andBit && xorBit) {
+        // XOR: invert existing pixel
+        data[idx] = 255 - data[idx];
+        data[idx + 1] = 255 - data[idx + 1];
+        data[idx + 2] = 255 - data[idx + 2];
+      }
+      // andBit && !xorBit: transparent — leave unchanged
+    }
+  }
+
+  ctx.putImageData(region, x0, y0);
+}
+
+/**
  * Dispatch pending mouse callback (called from tick loop in emu-exec.ts).
  * Returns true if a callback was dispatched (caller should continue tick loop).
  *
@@ -331,6 +446,10 @@ export function handleInt33(cpu: CPU, emu: Emulator): boolean {
  * onto the stack, then a small trampoline that pops them after RETF.
  * Since we can't inject code, we save registers in JS and restore on RETF detect.
  */
+// Mouse callback return trampoline location (written in emu-load.ts)
+const MOUSE_TRAMP_SEG = 0xF000;
+const MOUSE_TRAMP_OFF = 0x0500;
+
 export function dispatchMouseCallback(emu: Emulator): boolean {
   const m = emu.dosMouse;
   if (!m.pendingCallbackMask || !m.callbackMask || !m.callbackSeg) return false;
@@ -341,22 +460,38 @@ export function dispatchMouseCallback(emu: Emulator): boolean {
   const mask = m.pendingCallbackMask;
   m.pendingCallbackMask = 0;
 
-  // Real mouse drivers (CuteMouse etc.) save ALL registers + flags before
-  // calling the user callback and restore after RETF. We do the same in JS.
-  emu._mouseCallbackSavedRegs = {
-    regs: Int32Array.from(emu.cpu.reg), // all 8 GPRs (EAX-EDI)
-    ds: emu.cpu.ds, es: emu.cpu.es,
-    flags: emu.cpu.getFlags(), // materializes lazy flags
-  };
-
   const seg = m.callbackSeg;
   const off = m.callbackOff;
-
-  // Push far return address for RETF
+  const returnCS = emu.cpu.cs;
   const returnIP = (emu.cpu.eip - emu.cpu.segBase(emu.cpu.cs)) & 0xFFFF;
+
+  // Save SP to prevent nested dispatches (cleared when SP returns)
   emu._mouseCallbackSavedSP = emu.cpu.reg[4] & 0xFFFF;
-  emu.cpu.push16(emu.cpu.cs);
+
+  // Build a complete stack frame so the x86 trampoline at F000:0500
+  // restores ALL registers and returns to the interrupted code via IRET.
+  // Push order must match the trampoline's POP order (IRET first, then regs).
+
+  // 1) Interrupted context for IRET (trampoline pops last)
+  emu.cpu.push16(emu.cpu.getFlags() & 0xFFFF);
+  emu.cpu.push16(returnCS);
   emu.cpu.push16(returnIP);
+
+  // 2) All GP registers + segment regs (trampoline POPs in this order:
+  //    AX, BX, CX, DX, BP, SI, DI, DS, ES — so push in reverse)
+  emu.cpu.push16(emu.cpu.getReg16(EAX));
+  emu.cpu.push16(emu.cpu.getReg16(EBX));
+  emu.cpu.push16(emu.cpu.getReg16(ECX));
+  emu.cpu.push16(emu.cpu.getReg16(EDX));
+  emu.cpu.push16(emu.cpu.reg[5] & 0xFFFF); // BP
+  emu.cpu.push16(emu.cpu.getReg16(ESI));
+  emu.cpu.push16(emu.cpu.getReg16(EDI));
+  emu.cpu.push16(emu.cpu.ds);
+  emu.cpu.push16(emu.cpu.es);
+
+  // 3) Trampoline return address for callback's RETF
+  emu.cpu.push16(MOUSE_TRAMP_SEG);
+  emu.cpu.push16(MOUSE_TRAMP_OFF);
 
   // Set callback parameters per INT 33h convention:
   //   AX = event condition mask, BX = button state,

--- a/src/lib/emu/dos/mouse.ts
+++ b/src/lib/emu/dos/mouse.ts
@@ -56,9 +56,6 @@ export interface DosMouseState {
   sensX: number;  // mickeys per 8 pixels (default 8)
   sensY: number;
   doubleThreshold: number;
-  // Last browser mapped position for delta computation (-1 = uninitialized)
-  lastBrowserX: number;
-  lastBrowserY: number;
   // Graphics cursor shape (16x16 AND/XOR masks + hotspot)
   cursorAnd: Uint16Array;
   cursorXor: Uint16Array;
@@ -85,7 +82,6 @@ export function createDosMouseState(): DosMouseState {
     releaseY: [0, 0, 0],
     sensX: 8, sensY: 16,
     doubleThreshold: 64,
-    lastBrowserX: -1, lastBrowserY: -1,
     cursorAnd: Uint16Array.from(DEFAULT_CURSOR_AND),
     cursorXor: Uint16Array.from(DEFAULT_CURSOR_XOR),
     cursorHotX: DEFAULT_CURSOR_HOTX,
@@ -113,30 +109,14 @@ export function injectDosMouseEvent(
   const m = emu.dosMouse;
   if (!m.installed) return;
 
-  // Map browser pixel coordinates to virtual coordinate scale
-  const mappedX = px * m.maxX / (displayW - 1);
-  const mappedY = py * m.maxY / (displayH - 1);
+  // Map browser pixel coordinates directly to virtual coordinate scale
+  const newX = Math.max(m.minX, Math.min(m.maxX, Math.round(px * m.maxX / (displayW - 1))));
+  const newY = Math.max(m.minY, Math.min(m.maxY, Math.round(py * m.maxY / (displayH - 1))));
 
   let eventMask = 0;
 
-  // First event: initialize baseline, place cursor at browser position
-  if (m.lastBrowserX < 0) {
-    m.lastBrowserX = mappedX;
-    m.lastBrowserY = mappedY;
-    m.x = Math.max(m.minX, Math.min(m.maxX, Math.round(mappedX)));
-    m.y = Math.max(m.minY, Math.min(m.maxY, Math.round(mappedY)));
-  }
-
-  // Compute delta from last browser position, apply to m.x/m.y
-  // This way AX=4 (set position) is respected — we add movement on top of it
-  const dx = mappedX - m.lastBrowserX;
-  const dy = mappedY - m.lastBrowserY;
-  m.lastBrowserX = mappedX;
-  m.lastBrowserY = mappedY;
-
-  if (dx !== 0 || dy !== 0) {
-    const newX = Math.max(m.minX, Math.min(m.maxX, Math.round(m.x + dx)));
-    const newY = Math.max(m.minY, Math.min(m.maxY, Math.round(m.y + dy)));
+  // Update mickeys (relative movement counters) and position
+  if (newX !== m.x || newY !== m.y) {
     m.mickeysX += (newX - m.x);
     m.mickeysY += (newY - m.y);
     m.x = newX;
@@ -199,7 +179,6 @@ export function handleInt33(cpu: CPU, emu: Emulator): boolean {
       m.pressX = [0, 0, 0]; m.pressY = [0, 0, 0];
       m.releaseX = [0, 0, 0]; m.releaseY = [0, 0, 0];
       m.sensX = 8; m.sensY = 16; m.doubleThreshold = 64;
-      m.lastBrowserX = -1; m.lastBrowserY = -1;
       m.cursorAnd = Uint16Array.from(DEFAULT_CURSOR_AND);
       m.cursorXor = Uint16Array.from(DEFAULT_CURSOR_XOR);
       m.cursorHotX = DEFAULT_CURSOR_HOTX;
@@ -207,7 +186,6 @@ export function handleInt33(cpu: CPU, emu: Emulator): boolean {
       m.installed = true;
       cpu.setReg16(EAX, 0xFFFF); // mouse installed
       cpu.setReg16(EBX, 3);       // 3 buttons
-      console.log(`[INT 33h] AX=0 reset mouse, maxY=${m.maxY} isGfx=${emu.isGraphicsMode} mode=0x${emu.videoMode.toString(16)}`);
       return true;
     }
 
@@ -288,7 +266,6 @@ export function handleInt33(cpu: CPU, emu: Emulator): boolean {
       m.callbackMask = cpu.getReg16(ECX);
       m.callbackSeg = cpu.es;
       m.callbackOff = cpu.getReg16(EDX);
-      console.log(`[INT 33h] AX=0C set callback mask=0x${m.callbackMask.toString(16)} addr=${m.callbackSeg.toString(16)}:${m.callbackOff.toString(16)}`);
       return true;
     }
 

--- a/src/lib/emu/dos/video.ts
+++ b/src/lib/emu/dos/video.ts
@@ -2,6 +2,7 @@ import type { CPU } from '../x86/cpu';
 import type { Emulator } from '../emulator';
 import { VGA_MODES } from './vga';
 import { ROM_FONT_8X8_SEG, ROM_FONT_8X8_OFF, ROM_FONT_CGA_OFF } from './vga-font-data';
+import { updateMouseRangeForMode } from './mouse';
 
 const EAX = 0, ECX = 1, EDX = 2, EBX = 3, ESP = 4, EBP = 5, ESI = 6, EDI = 7;
 
@@ -259,6 +260,9 @@ function setVideoMode(cpu: CPU, emu: Emulator, modeNum: number): void {
       }
     }
   }
+
+  // Update mouse coordinate range to match the new video mode
+  updateMouseRangeForMode(emu);
 }
 
 // --- Pixel operations for all graphics modes ---

--- a/src/lib/emu/emu-exec.ts
+++ b/src/lib/emu/emu-exec.ts
@@ -734,10 +734,7 @@ export function emuTick(emu: Emulator): void {
           }
           emu._dosHalted = false;
         }
-        // Dispatch pending mouse callback (throttled to ~once per 4096 instructions)
-        if (emu.dosMouse.pendingCallbackMask && emu._mouseCallbackSavedSP < 0 && emu._hwIntSavedSP < 0) {
-          dispatchMouseCallback(emu);
-        }
+        // (mouse callback dispatch moved to per-instruction check above)
       }
     }
     if (emu.isDOS) {
@@ -793,10 +790,12 @@ export function emuTick(emu: Emulator): void {
     } else if (emu._pendingHwInts.length === 0) {
       emu._hwKeyDelay = 0;
     }
-    // Mouse callback dispatch is done in the periodic time check (every 4096
-    // instructions) to match real hardware rates. Dispatching at every instruction
-    // fires callbacks far too frequently, corrupting programs that share state
-    // between their main code and the callback handler.
+    // Dispatch pending mouse callback (far call via trampoline at F000:0500).
+    // Safe at every instruction boundary since the trampoline handles register
+    // restoration via real x86 POPs + IRET (no fragile JS-side detection).
+    if (emu.dosMouse.pendingCallbackMask && emu._mouseCallbackSavedSP < 0 && emu._hwIntSavedSP < 0) {
+      dispatchMouseCallback(emu);
+    }
     if (emu._pendingHwInts.length > 0 && emu._hwIntSavedSP < 0 && !emu.cpu._inhibitIRQ) {
       // _inhibitIRQ: MOV SS/POP SS inhibits for 1 instruction (real x86 behavior).
       // Note: IF flag (CLI/STI) is NOT checked. Many DOS demos run rendering

--- a/src/lib/emu/emu-exec.ts
+++ b/src/lib/emu/emu-exec.ts
@@ -677,17 +677,11 @@ export function emuTick(emu: Emulator): void {
         emu._int09ReturnCS = -1;
       }
     }
-    // Detect RETF from mouse callback by monitoring SP — restore all saved state
+    // Detect mouse callback completion: SP returned to pre-dispatch level.
+    // The trampoline at F000:0500 handles register restoration via x86 POPs+IRET;
+    // this check just clears the "active" flag so the next callback can dispatch.
     if (emu._mouseCallbackSavedSP >= 0 && (emu.cpu.reg[4] & 0xFFFF) >= emu._mouseCallbackSavedSP) {
       emu._mouseCallbackSavedSP = -1;
-      const saved = emu._mouseCallbackSavedRegs;
-      if (saved) {
-        emu.cpu.reg.set(saved.regs);
-        emu.cpu.ds = saved.ds;
-        emu.cpu.es = saved.es;
-        emu.cpu.setFlags(saved.flags);
-        emu._mouseCallbackSavedRegs = undefined;
-      }
     }
     // Detect IRET from hardware interrupt handler by monitoring SP (RM dispatch)
     // or IF flag restoration (PM IDT dispatch).
@@ -739,6 +733,10 @@ export function emuTick(emu: Emulator): void {
             emu._pendingHwInts.push(timerInt);
           }
           emu._dosHalted = false;
+        }
+        // Dispatch pending mouse callback (throttled to ~once per 4096 instructions)
+        if (emu.dosMouse.pendingCallbackMask && emu._mouseCallbackSavedSP < 0 && emu._hwIntSavedSP < 0) {
+          dispatchMouseCallback(emu);
         }
       }
     }
@@ -795,10 +793,10 @@ export function emuTick(emu: Emulator): void {
     } else if (emu._pendingHwInts.length === 0) {
       emu._hwKeyDelay = 0;
     }
-    // Dispatch pending mouse callback (far call, returns via RETF)
-    if (emu.dosMouse.pendingCallbackMask && emu._mouseCallbackSavedSP < 0 && emu._hwIntSavedSP < 0) {
-      dispatchMouseCallback(emu);
-    }
+    // Mouse callback dispatch is done in the periodic time check (every 4096
+    // instructions) to match real hardware rates. Dispatching at every instruction
+    // fires callbacks far too frequently, corrupting programs that share state
+    // between their main code and the callback handler.
     if (emu._pendingHwInts.length > 0 && emu._hwIntSavedSP < 0 && !emu.cpu._inhibitIRQ) {
       // _inhibitIRQ: MOV SS/POP SS inhibits for 1 instruction (real x86 behavior).
       // Note: IF flag (CLI/STI) is NOT checked. Many DOS demos run rendering

--- a/src/lib/emu/emu-load.ts
+++ b/src/lib/emu/emu-load.ts
@@ -1098,6 +1098,27 @@ function setupDosEnvironment(emu: Emulator, mz: import('./mz-loader').LoadedMZ):
     defaultVec.set(intNum, (DOS_KERNEL_SEG << 16) | off);
   }
 
+  // Mouse callback return trampoline at F000:0500
+  // When the user callback does RETF, it arrives here.
+  // The stack contains all saved registers + FLAGS/CS/IP for IRET.
+  // This code restores everything and returns to the interrupted program.
+  {
+    const TRAMP = BIOS_BASE + 0x0500; // F000:0500
+    const code = [
+      0x07,       // POP ES
+      0x1F,       // POP DS
+      0x5F,       // POP DI
+      0x5E,       // POP SI
+      0x5D,       // POP BP
+      0x5A,       // POP DX
+      0x59,       // POP CX
+      0x5B,       // POP BX
+      0x58,       // POP AX
+      0xCF,       // IRET → pops IP, CS, FLAGS
+    ];
+    for (let j = 0; j < code.length; j++) emu.memory.writeU8(TRAMP + j, code[j]);
+  }
+
   for (let i = 0; i < 256; i++) {
     const vec = defaultVec.get(i)!;
     emu.memory.writeU16(i * 4, vec & 0xFFFF);

--- a/src/lib/emu/emulator.ts
+++ b/src/lib/emu/emulator.ts
@@ -345,9 +345,6 @@ export class Emulator {
   isDOS = false;
   dosMouse = createDosMouseState();
   _mouseCallbackSavedSP = -1;
-  _mouseCallbackSavedRegs?: {
-    regs: Int32Array; ds: number; es: number; flags: number;
-  };
   dosKeyBuffer: { ascii: number; scan: number }[] = [];
   _dosWaitingForKey: false | 'read' | 'peek' = false;
   _dosExtKeyPending?: number; // scan code pending for second getch() call on extended keys


### PR DESCRIPTION
 ## Summary

  - **Graphics cursor**: draws a 16×16 AND/XOR mask cursor on top of the VGA framebuffer without modifying VRAM. Supports
  custom shapes via INT 33h AX=9. 
  - **Trampoline-based callback dispatch**: mouse callbacks (INT 33h AX=0C) now save all registers on the real x86 stack
  and RETF to a trampoline at F000:0500 (POP regs + IRET). Replaces the previous JS-side SP detection which corrupted
  execution in programs like NeoPaint.
  - **Absolute positioning**: browser coordinates are mapped directly to DOS virtual coordinates instead of accumulating
  deltas, eliminating cursor drift.
  - **Video mode sync**: mouse range (maxX/maxY) is automatically adjusted on video mode changes via INT 10h.

  Tested with NeoPaint (320×200 256-color, 640×350 16-color, 640×480 2-color, 640×480 16-color — all with callback-based
  mouse) and QBasic (text mode, polling-based mouse).

  ## Test plan

  - [X] NeoPaint: cursor tracks the mouse, clicks work, no crash on hover
  - [X] QBasic: mouse clicks are reliably registered (no lost clicks)
  - [X] DOS programs without mouse: no regression (mouse only activates after INT 33h AX=0)