### PR TITLE
Win32 emulator fixes uncovered while bringing up the amoeba demo

### DIFF
--- a/src/components/win2k/ComboBox.tsx
+++ b/src/components/win2k/ComboBox.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'preact/hooks';
+import { createPortal } from 'preact/compat';
 import type { ComponentChildren } from 'preact';
 
 /**
@@ -63,19 +64,41 @@ export function ComboBox({ items, selectedIndex = -1, onSelect, onOpen, font, di
   // Interactive mode
   const [open, setOpen] = useState(false);
   const [hoverIdx, setHoverIdx] = useState(-1);
+  const [dropdownRect, setDropdownRect] = useState<{ left: number; top: number; width: number } | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
 
-  // Close dropdown on click outside
+  // Close dropdown on click outside (both container and list)
   useEffect(() => {
     if (!open) return;
     const handler = (e: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
+      const t = e.target as Node;
+      if (containerRef.current?.contains(t)) return;
+      if (listRef.current?.contains(t)) return;
+      setOpen(false);
     };
     document.addEventListener('pointerdown', handler, true);
     return () => document.removeEventListener('pointerdown', handler, true);
+  }, [open]);
+
+  // Track the container's viewport position while open so the portal stays anchored.
+  // Real Windows dropdowns float over everything — use position:fixed to escape
+  // any clipping/stacking context of the hosting window.
+  useEffect(() => {
+    if (!open) { setDropdownRect(null); return; }
+    const update = () => {
+      const el = containerRef.current;
+      if (!el) return;
+      const r = el.getBoundingClientRect();
+      setDropdownRect({ left: r.left, top: r.bottom, width: r.width });
+    };
+    update();
+    window.addEventListener('resize', update);
+    window.addEventListener('scroll', update, true);
+    return () => {
+      window.removeEventListener('resize', update);
+      window.removeEventListener('scroll', update, true);
+    };
   }, [open]);
 
   // Scroll selected item into view when dropdown opens
@@ -84,20 +107,7 @@ export function ComboBox({ items, selectedIndex = -1, onSelect, onOpen, font, di
       const child = listRef.current.children[selectedIndex] as HTMLElement | undefined;
       if (child) child.scrollIntoView({ block: 'nearest' });
     }
-  }, [open, selectedIndex]);
-
-  // Lift the parent wrapper above sibling ComboBoxes while the dropdown is open.
-  // The dropdown list is rendered inside this ComboBox's own stacking context,
-  // so setting zIndex on our root alone can't escape a positioned parent.
-  useEffect(() => {
-    const parent = containerRef.current?.parentElement;
-    if (!parent) return;
-    if (open) {
-      const prev = parent.style.zIndex;
-      parent.style.zIndex = '10000';
-      return () => { parent.style.zIndex = prev; };
-    }
-  }, [open]);
+  }, [open, selectedIndex, dropdownRect]);
 
   const fontStyle = font || fontCSS || '11px/1 "Tahoma", "MS Sans Serif", sans-serif';
   const selectedText = selectedIndex >= 0 && selectedIndex < items.length
@@ -123,9 +133,6 @@ export function ComboBox({ items, selectedIndex = -1, onSelect, onOpen, font, di
   return (
     <div ref={containerRef} style={{
       position: 'relative', width: '100%', height: '100%',
-      // When the dropdown is open, lift the whole container above sibling controls.
-      // Otherwise a sibling ComboBox rendered later in the DOM paints over this one's list.
-      zIndex: open ? 10000 : 'auto',
     }}>
       {/* Outer sunken container — the whole combobox shares one border */}
       <div
@@ -176,13 +183,15 @@ export function ComboBox({ items, selectedIndex = -1, onSelect, onOpen, font, di
         </div>
       </div>
 
-      {open && items.length > 0 && (
+      {open && items.length > 0 && dropdownRect && createPortal(
         <div
           ref={listRef}
           style={{
-            position: 'absolute', top: '100%', left: 0,
-            width: '100%', maxHeight: 160,
-            overflowY: items.length > 10 ? 'scroll' : 'auto',
+            position: 'fixed',
+            left: dropdownRect.left, top: dropdownRect.top,
+            width: dropdownRect.width,
+            maxHeight: Math.max(40, window.innerHeight - dropdownRect.top - 4),
+            overflowY: 'auto',
             border: '1px solid #000',
             background: '#FFF',
             zIndex: 10000,
@@ -214,7 +223,8 @@ export function ComboBox({ items, selectedIndex = -1, onSelect, onOpen, font, di
               </div>
             );
           })}
-        </div>
+        </div>,
+        document.body
       )}
     </div>
   );

--- a/src/components/win2k/ComboBox.tsx
+++ b/src/components/win2k/ComboBox.tsx
@@ -86,6 +86,19 @@ export function ComboBox({ items, selectedIndex = -1, onSelect, onOpen, font, di
     }
   }, [open, selectedIndex]);
 
+  // Lift the parent wrapper above sibling ComboBoxes while the dropdown is open.
+  // The dropdown list is rendered inside this ComboBox's own stacking context,
+  // so setting zIndex on our root alone can't escape a positioned parent.
+  useEffect(() => {
+    const parent = containerRef.current?.parentElement;
+    if (!parent) return;
+    if (open) {
+      const prev = parent.style.zIndex;
+      parent.style.zIndex = '10000';
+      return () => { parent.style.zIndex = prev; };
+    }
+  }, [open]);
+
   const fontStyle = font || fontCSS || '11px/1 "Tahoma", "MS Sans Serif", sans-serif';
   const selectedText = selectedIndex >= 0 && selectedIndex < items.length
     ? items[selectedIndex] : '';
@@ -110,6 +123,9 @@ export function ComboBox({ items, selectedIndex = -1, onSelect, onOpen, font, di
   return (
     <div ref={containerRef} style={{
       position: 'relative', width: '100%', height: '100%',
+      // When the dropdown is open, lift the whole container above sibling controls.
+      // Otherwise a sibling ComboBox rendered later in the DOM paints over this one's list.
+      zIndex: open ? 10000 : 'auto',
     }}>
       {/* Outer sunken container — the whole combobox shares one border */}
       <div

--- a/src/lib/emu/emulator.ts
+++ b/src/lib/emu/emulator.ts
@@ -555,8 +555,10 @@ export class Emulator {
   _diagThunkIdx = 0;
   _diagThunkSize = 64;
   diagThunk(name: string) {
-    const sp = this.cpu.reg[4] & 0xFFFF;
-    this._diagThunkRing[this._diagThunkIdx % this._diagThunkSize] = `SP=${sp.toString(16)} ${name}`;
+    const sp = this.cpu.reg[4] >>> 0;
+    let retAddr = 0;
+    try { retAddr = this.memory.readU32(sp) >>> 0; } catch { /* ignore */ }
+    this._diagThunkRing[this._diagThunkIdx % this._diagThunkSize] = `retEIP=${retAddr.toString(16)} SP=${(sp & 0xFFFF).toString(16)} ${name}`;
     this._diagThunkIdx++;
   }
   diagThunkDump(): string {

--- a/src/lib/emu/format.ts
+++ b/src/lib/emu/format.ts
@@ -238,6 +238,41 @@ export function scanString(
         // %n does not count as a matched field
         break;
       }
+      case 'f': case 'F': case 'e': case 'E': case 'g': case 'G': case 'a': case 'A': {
+        let numStr = '';
+        const maxChars = Math.min(width, str.length - si);
+        let j = 0;
+        if (j < maxChars && (str[si + j] === '-' || str[si + j] === '+')) { numStr += str[si + j]; j++; }
+        while (j < maxChars && str[si + j] >= '0' && str[si + j] <= '9') { numStr += str[si + j]; j++; }
+        if (j < maxChars && str[si + j] === '.') {
+          numStr += str[si + j]; j++;
+          while (j < maxChars && str[si + j] >= '0' && str[si + j] <= '9') { numStr += str[si + j]; j++; }
+        }
+        if (j < maxChars && (str[si + j] === 'e' || str[si + j] === 'E')) {
+          numStr += str[si + j]; j++;
+          if (j < maxChars && (str[si + j] === '-' || str[si + j] === '+')) { numStr += str[si + j]; j++; }
+          while (j < maxChars && str[si + j] >= '0' && str[si + j] <= '9') { numStr += str[si + j]; j++; }
+        }
+        const val = parseFloat(numStr);
+        if (numStr === '' || numStr === '-' || numStr === '+' || numStr === '.' || isNaN(val)) break;
+        si += j;
+        if (!suppress) {
+          const ptr = readArg(argIdx++);
+          const isDouble = lengthMod === 'l' || lengthMod === 'L';
+          const buf = new ArrayBuffer(8);
+          const dv = new DataView(buf);
+          if (isDouble) {
+            dv.setFloat64(0, val, true);
+            mem.writeU32(ptr, dv.getUint32(0, true));
+            mem.writeU32(ptr + 4, dv.getUint32(4, true));
+          } else {
+            dv.setFloat32(0, val, true);
+            mem.writeU32(ptr, dv.getUint32(0, true));
+          }
+          matched++;
+        }
+        break;
+      }
       default:
         // Unknown specifier — stop
         return matched;

--- a/src/lib/emu/win32/dsound.ts
+++ b/src/lib/emu/win32/dsound.ts
@@ -161,6 +161,43 @@ function createSoundBuffer(emu: Emulator, bufferSize: number = 4096,
 export function registerDsound(emu: Emulator): void {
   const dsound = emu.registerDll('DSOUND.DLL');
 
+  // DirectSoundEnumerateA(callback, context) — invoke callback for each device.
+  // Windows returns the NULL-GUID "Primary Sound Driver" first, then each actual
+  // device. Our emulator has no real audio, but enumerating at least a primary +
+  // one default device matches what apps expect to populate "sound device" UIs.
+  const enumerate = (wide: boolean) => () => {
+    const callback = emu.readArg(0);
+    const context = emu.readArg(1);
+    if (!callback) return DS_OK;
+
+    const writeStr = (s: string): number => {
+      const p = emu.allocHeap((s.length + 1) * (wide ? 2 : 1));
+      if (wide) {
+        for (let i = 0; i < s.length; i++) emu.memory.writeU16(p + i * 2, s.charCodeAt(i));
+        emu.memory.writeU16(p + s.length * 2, 0);
+      } else {
+        for (let i = 0; i < s.length; i++) emu.memory.writeU8(p + i, s.charCodeAt(i));
+        emu.memory.writeU8(p + s.length, 0);
+      }
+      return p;
+    };
+    const emptyStr = writeStr('');
+
+    // Entry 1: primary sound driver (NULL GUID)
+    const primaryDesc = writeStr('Primary Sound Driver');
+    const r1 = emu.callCallback(callback, [0, primaryDesc, emptyStr, context]);
+    if (r1 === 0) return DS_OK; // callback returned FALSE — stop enumeration
+
+    // Entry 2: our fake default device
+    const fakeGuid = emu.allocHeap(16);
+    for (let i = 0; i < 16; i++) emu.memory.writeU8(fakeGuid + i, i + 1);
+    const deviceDesc = writeStr('Default Audio Device (emulated)');
+    emu.callCallback(callback, [fakeGuid, deviceDesc, emptyStr, context]);
+    return DS_OK;
+  };
+  dsound.register('DirectSoundEnumerateA', 2, enumerate(false));
+  dsound.register('DirectSoundEnumerateW', 2, enumerate(true));
+
   // DirectSoundCreate(lpGuid, ppDS, pUnkOuter) → HRESULT
   dsound.register('DirectSoundCreate', 3, () => {
     const _lpGuid = emu.readArg(0);

--- a/src/lib/emu/win32/gl-context.ts
+++ b/src/lib/emu/win32/gl-context.ts
@@ -497,8 +497,8 @@ export class GL1Context {
     stack[stack.length - 1] = m;
   }
 
-  private get modelview(): Float32Array { return this.modelviewStack[this.modelviewStack.length - 1]; }
-  private get projection(): Float32Array { return this.projectionStack[this.projectionStack.length - 1]; }
+  get modelview(): Float32Array { return this.modelviewStack[this.modelviewStack.length - 1]; }
+  get projection(): Float32Array { return this.projectionStack[this.projectionStack.length - 1]; }
 
   private markDirty(): void { this.uniformsDirty = true; }
 
@@ -651,6 +651,34 @@ export class GL1Context {
 
   shadeModel(mode: number): void {
     this.cmd(() => { this._shadeModel = mode; });
+  }
+
+  colorMask(r: boolean, g: boolean, b: boolean, a: boolean): void {
+    this.cmd(() => { this.gl.colorMask(r, g, b, a); });
+  }
+
+  depthMask(flag: boolean): void {
+    this.cmd(() => { this.gl.depthMask(flag); });
+  }
+
+  stencilMask(mask: number): void {
+    this.cmd(() => { this.gl.stencilMask(mask); });
+  }
+
+  stencilFunc(func: number, ref: number, mask: number): void {
+    this.cmd(() => { this.gl.stencilFunc(func, ref, mask); });
+  }
+
+  stencilOp(fail: number, zfail: number, zpass: number): void {
+    this.cmd(() => { this.gl.stencilOp(fail, zfail, zpass); });
+  }
+
+  clearStencil(s: number): void {
+    this.cmd(() => { this.gl.clearStencil(s); });
+  }
+
+  polygonOffset(factor: number, units: number): void {
+    this.cmd(() => { this.gl.polygonOffset(factor, units); });
   }
 
   blendFunc(sfactor: number, dfactor: number): void {
@@ -858,6 +886,29 @@ export class GL1Context {
         glFormat = gl.RGBA; glInternal = gl.RGBA;
       }
       gl.texImage2D(gl.TEXTURE_2D, level, glInternal, width, height, border, glFormat, gl.UNSIGNED_BYTE, pixels);
+    });
+  }
+
+  build2DMipmaps(target: number, internalFormat: number,
+                 width: number, height: number,
+                 format: number, type: number, pixels: Uint8Array | null): void {
+    this.cmd(() => {
+      const gl = this.gl;
+      let glFormat: number;
+      let glInternal: number;
+      if (format === GL_RGBA || internalFormat === GL_RGBA || internalFormat === 4) {
+        glFormat = gl.RGBA; glInternal = gl.RGBA;
+      } else if (format === GL_RGB || internalFormat === GL_RGB || internalFormat === 3) {
+        glFormat = gl.RGB; glInternal = gl.RGB;
+      } else if (format === GL_LUMINANCE || internalFormat === GL_LUMINANCE || internalFormat === 1) {
+        glFormat = gl.LUMINANCE; glInternal = gl.LUMINANCE;
+      } else if (format === GL_LUMINANCE_ALPHA || internalFormat === GL_LUMINANCE_ALPHA || internalFormat === 2) {
+        glFormat = gl.LUMINANCE_ALPHA; glInternal = gl.LUMINANCE_ALPHA;
+      } else {
+        glFormat = gl.RGBA; glInternal = gl.RGBA;
+      }
+      gl.texImage2D(gl.TEXTURE_2D, 0, glInternal, width, height, 0, glFormat, gl.UNSIGNED_BYTE, pixels);
+      gl.generateMipmap(gl.TEXTURE_2D);
     });
   }
 
@@ -1153,6 +1204,20 @@ export class GL1Context {
       case GL_MAX_LIGHTS: return 2;
       default: return 0;
     }
+  }
+
+  // Return a 4-entry viewport array [x,y,w,h], or null if pname is not GL_VIEWPORT.
+  getViewport(): [number, number, number, number] {
+    const p = this.gl.getParameter(this.gl.VIEWPORT);
+    return [p[0], p[1], p[2], p[3]];
+  }
+
+  // Return the current projection or modelview matrix as a 16-entry Float32Array (column-major).
+  getMatrix(pname: number): Float32Array | null {
+    // GL_MODELVIEW_MATRIX=0x0BA6, GL_PROJECTION_MATRIX=0x0BA7
+    if (pname === 0x0BA6) return this.modelview;
+    if (pname === 0x0BA7) return this.projection;
+    return null;
   }
 
   getTexEnviv(pname: number): number {

--- a/src/lib/emu/win32/glu32.ts
+++ b/src/lib/emu/win32/glu32.ts
@@ -9,6 +9,28 @@ function readDouble(emu: Emulator, argIdx: number): number {
   return buf.getFloat64(0, true);
 }
 
+function readDoubleMem(emu: Emulator, addr: number): number {
+  const buf = new DataView(new ArrayBuffer(8));
+  buf.setUint32(0, emu.memory.readU32(addr), true);
+  buf.setUint32(4, emu.memory.readU32(addr + 4), true);
+  return buf.getFloat64(0, true);
+}
+
+function writeDoubleMem(emu: Emulator, addr: number, val: number): void {
+  const buf = new DataView(new ArrayBuffer(8));
+  buf.setFloat64(0, val, true);
+  emu.memory.writeU32(addr, buf.getUint32(0, true));
+  emu.memory.writeU32(addr + 4, buf.getUint32(4, true));
+}
+
+// OpenGL matrices are stored column-major: m[col*4 + row].
+function mat4MulVec4(m: Float64Array, v: Float64Array, out: Float64Array): void {
+  for (let r = 0; r < 4; r++) {
+    out[r] = m[0 * 4 + r] * v[0] + m[1 * 4 + r] * v[1] +
+             m[2 * 4 + r] * v[2] + m[3 * 4 + r] * v[3];
+  }
+}
+
 export function registerGlu32(emu: Emulator): void {
   const glu32 = emu.registerDll('GLU32.DLL');
 
@@ -39,6 +61,82 @@ export function registerGlu32(emu: Emulator): void {
     const upX = readDouble(emu, 12), upY = readDouble(emu, 14), upZ = readDouble(emu, 16);
     emu.glContext?.lookAt(eyeX, eyeY, eyeZ, centerX, centerY, centerZ, upX, upY, upZ);
     return 0;
+  });
+
+  // gluBuild2DMipmaps(target, internalFormat, width, height, format, type, data)
+  glu32.register('gluBuild2DMipmaps', 7, () => {
+    const target = emu.readArg(0);
+    const internalFormat = emu.readArg(1);
+    const width = emu.readArg(2);
+    const height = emu.readArg(3);
+    const format = emu.readArg(4);
+    const type = emu.readArg(5);
+    const pixelsPtr = emu.readArg(6);
+
+    if (!emu.glContext) return 0;
+    if (target !== 0x0DE1) return 0; // GL_TEXTURE_2D
+
+    let pixels: Uint8Array | null = null;
+    if (pixelsPtr && width > 0 && height > 0) {
+      let bpp = 4;
+      if (format === 0x1907) bpp = 3;        // GL_RGB
+      else if (format === 0x1909) bpp = 1;   // GL_LUMINANCE
+      else if (format === 0x190A) bpp = 2;   // GL_LUMINANCE_ALPHA
+      else if (format === 0x1906) bpp = 1;   // GL_ALPHA
+      const size = width * height * bpp;
+      pixels = new Uint8Array(size);
+      for (let i = 0; i < size; i++) pixels[i] = emu.memory.readU8(pixelsPtr + i);
+    }
+
+    emu.glContext.build2DMipmaps(target, internalFormat, width, height, format, type, pixels);
+    return 0;
+  });
+
+  // gluProject(objX, objY, objZ, model[16], proj[16], view[4], winX*, winY*, winZ*)
+  //  3 doubles (6 dwords) + 6 pointers = 12 dwords
+  glu32.register('gluProject', 12, () => {
+    const objX = readDouble(emu, 0);
+    const objY = readDouble(emu, 2);
+    const objZ = readDouble(emu, 4);
+    const modelPtr = emu.readArg(6);
+    const projPtr = emu.readArg(7);
+    const viewPtr = emu.readArg(8);
+    const winXPtr = emu.readArg(9);
+    const winYPtr = emu.readArg(10);
+    const winZPtr = emu.readArg(11);
+
+    const model = new Float64Array(16);
+    const proj = new Float64Array(16);
+    for (let i = 0; i < 16; i++) {
+      model[i] = readDoubleMem(emu, modelPtr + i * 8);
+      proj[i] = readDoubleMem(emu, projPtr + i * 8);
+    }
+    const vp = [
+      emu.memory.readI32(viewPtr),
+      emu.memory.readI32(viewPtr + 4),
+      emu.memory.readI32(viewPtr + 8),
+      emu.memory.readI32(viewPtr + 12),
+    ];
+
+    const v = new Float64Array([objX, objY, objZ, 1]);
+    const t = new Float64Array(4);
+    mat4MulVec4(model, v, t);
+    const c = new Float64Array(4);
+    mat4MulVec4(proj, t, c);
+    if (c[3] === 0) return 0; // GL_FALSE
+
+    const ndcX = c[0] / c[3];
+    const ndcY = c[1] / c[3];
+    const ndcZ = c[2] / c[3];
+
+    const winX = vp[0] + vp[2] * (ndcX + 1) * 0.5;
+    const winY = vp[1] + vp[3] * (ndcY + 1) * 0.5;
+    const winZ = (ndcZ + 1) * 0.5;
+
+    if (winXPtr) writeDoubleMem(emu, winXPtr, winX);
+    if (winYPtr) writeDoubleMem(emu, winYPtr, winY);
+    if (winZPtr) writeDoubleMem(emu, winZPtr, winZ);
+    return 1; // GL_TRUE
   });
 
   glu32.register('gluScaleImage', 9, () => {

--- a/src/lib/emu/win32/msvcrt.ts
+++ b/src/lib/emu/win32/msvcrt.ts
@@ -1,9 +1,82 @@
 import type { Emulator } from '../emulator';
 import { formatString, scanString, stackArgReader, vaListArgReader } from '../format';
 import { emuCompleteThunk } from '../emu-exec';
+import { fpuPush } from '../x86/fpu';
 
 export function registerMsvcrt(emu: Emulator): void {
   const msvcrt = emu.registerDll('MSVCRT.DLL');
+
+  const readDoubleArg = (i: number): number => {
+    const lo = emu.readArg(i);
+    const hi = emu.readArg(i + 1);
+    const buf = new DataView(new ArrayBuffer(8));
+    buf.setUint32(0, lo, true);
+    buf.setUint32(4, hi, true);
+    return buf.getFloat64(0, true);
+  };
+  const unary = (fn: (x: number) => number) => () => {
+    fpuPush(emu.cpu, fn(readDoubleArg(0)));
+    return 0;
+  };
+  const binary = (fn: (x: number, y: number) => number) => () => {
+    fpuPush(emu.cpu, fn(readDoubleArg(0), readDoubleArg(2)));
+    return 0;
+  };
+  msvcrt.register('sin',   0, unary(Math.sin));
+  msvcrt.register('cos',   0, unary(Math.cos));
+  msvcrt.register('tan',   0, unary(Math.tan));
+  msvcrt.register('asin',  0, unary(Math.asin));
+  msvcrt.register('acos',  0, unary(Math.acos));
+  msvcrt.register('atan',  0, unary(Math.atan));
+  msvcrt.register('sinh',  0, unary(Math.sinh));
+  msvcrt.register('cosh',  0, unary(Math.cosh));
+  msvcrt.register('tanh',  0, unary(Math.tanh));
+  msvcrt.register('sqrt',  0, unary(Math.sqrt));
+  msvcrt.register('exp',   0, unary(Math.exp));
+  msvcrt.register('log',   0, unary(Math.log));
+  msvcrt.register('log10', 0, unary(Math.log10));
+  msvcrt.register('fabs',  0, unary(Math.abs));
+  msvcrt.register('ceil',  0, unary(Math.ceil));
+  msvcrt.register('floor', 0, unary(Math.floor));
+  msvcrt.register('atan2', 0, binary(Math.atan2));
+  msvcrt.register('pow',   0, binary(Math.pow));
+  msvcrt.register('fmod',  0, binary((x, y) => x - Math.trunc(x / y) * y));
+  msvcrt.register('hypot', 0, binary(Math.hypot));
+  msvcrt.register('_hypot', 0, binary(Math.hypot));
+  msvcrt.register('ldexp', 0, () => {
+    const x = readDoubleArg(0);
+    const n = emu.readArg(2) | 0;
+    fpuPush(emu.cpu, x * Math.pow(2, n));
+    return 0;
+  });
+
+  // int *_errno(void) — returns pointer to thread-local errno
+  const errnoVar = emu.allocHeap(4);
+  emu.memory.writeU32(errnoVar, 0);
+  msvcrt.register('_errno', 0, () => errnoVar);
+
+  // void _fpreset(void) — reset FPU state (no-op; FPU handled by emulator)
+  msvcrt.register('_fpreset', 0, () => 0);
+
+  // int _isnan(double x) — return non-zero if x is NaN
+  msvcrt.register('_isnan', 0, () => {
+    const lo = emu.readArg(0);
+    const hi = emu.readArg(1);
+    const buf = new DataView(new ArrayBuffer(8));
+    buf.setUint32(0, lo, true);
+    buf.setUint32(4, hi, true);
+    return Number.isNaN(buf.getFloat64(0, true)) ? 1 : 0;
+  });
+
+
+  // void _assert(const char *expr, const char *file, unsigned line) — cdecl, [[noreturn]]
+  msvcrt.register('_assert', 0, () => {
+    const expr = emu.memory.readCString(emu.readArg(0));
+    const file = emu.memory.readCString(emu.readArg(1));
+    const line = emu.readArg(2);
+    console.error(`[MSVCRT _assert] ${file}:${line} — assertion failed: ${expr}`);
+    return 0;
+  });
 
   msvcrt.register('_initterm', 0, () => {
     const start = emu.readArg(0);
@@ -714,6 +787,15 @@ export function registerMsvcrt(emu: Emulator): void {
   const stdoutFilePtr = iobBase + 32;  // FILE* for stdout
   const stderrFilePtr = iobBase + 64;  // FILE* for stderr
 
+  // int _fileno(FILE *stream) — return fd associated with stream
+  msvcrt.register('_fileno', 0, () => {
+    const filePtr = emu.readArg(0);
+    if (filePtr === stdinFilePtr) return 0;
+    if (filePtr === stdoutFilePtr) return 1;
+    if (filePtr === stderrFilePtr) return 2;
+    return -1;
+  });
+
   msvcrt.register('fprintf', 0, () => {
     const filePtr = emu.readArg(0);
     const fmtPtr = emu.readArg(1);
@@ -1245,7 +1327,7 @@ export function registerMsvcrt(emu: Emulator): void {
   // When thunk fires: stack is [retAddr, buf, ...]
   // After completeThunk (cdecl nArgs=0): ESP += 4 (pop retAddr), EIP = retAddr
   // Caller then cleans up args. We save the post-completeThunk state.
-  msvcrt.register('_setjmp3', 0, () => {
+  const setjmpImpl = () => {
     const buf = emu.readArg(0);
     const ESP = 4, EBP = 5, EBX = 3, EDI = 7, ESI = 6;
     const retAddr = emu.memory.readU32(emu.cpu.reg[ESP] >>> 0);
@@ -1257,7 +1339,9 @@ export function registerMsvcrt(emu: Emulator): void {
     emu.memory.writeU32(buf + 16, (emu.cpu.reg[ESP] + 4) >>> 0);
     emu.memory.writeU32(buf + 20, retAddr);
     return 0;
-  });
+  };
+  msvcrt.register('_setjmp3', 0, setjmpImpl);
+  msvcrt.register('_setjmp', 0, setjmpImpl);
 
   // longjmp(jmp_buf, value) — restore CPU state and return value to setjmp call site
   msvcrt.register('longjmp', 0, () => {
@@ -1380,10 +1464,182 @@ export function registerMsvcrt(emu: Emulator): void {
     return idx >= 0 ? haystack + idx : 0;
   });
 
+  // void (*signal(int sig, void (*handler)(int)))(int) — install handler, return previous (SIG_DFL=0)
+  msvcrt.register('signal', 0, () => 0);
+
+  // char *_strdup(const char *s) — allocates a copy
+  msvcrt.register('_strdup', 0, () => {
+    const s = emu.memory.readCString(emu.readArg(0));
+    const p = emu.allocHeap(s.length + 1);
+    emu.memory.writeCString(p, s);
+    return p;
+  });
+  msvcrt.register('strdup', 0, () => {
+    const s = emu.memory.readCString(emu.readArg(0));
+    const p = emu.allocHeap(s.length + 1);
+    emu.memory.writeCString(p, s);
+    return p;
+  });
+
+  // char *strtok(char *str, const char *delim) — thread-unsafe, keep state in closure
+  let strtokPtr = 0;
+  msvcrt.register('strtok', 0, () => {
+    const strArg = emu.readArg(0);
+    const delimPtr = emu.readArg(1);
+    const delim = emu.memory.readCString(delimPtr);
+    const set = new Set(delim);
+    let p = strArg !== 0 ? strArg : strtokPtr;
+    if (!p) return 0;
+    // Skip leading delims
+    while (set.has(String.fromCharCode(emu.memory.readU8(p)))) {
+      if (emu.memory.readU8(p) === 0) { strtokPtr = 0; return 0; }
+      p++;
+    }
+    if (emu.memory.readU8(p) === 0) { strtokPtr = 0; return 0; }
+    const start = p;
+    // Advance until delim or NUL
+    while (emu.memory.readU8(p) !== 0 && !set.has(String.fromCharCode(emu.memory.readU8(p)))) p++;
+    if (emu.memory.readU8(p) === 0) {
+      strtokPtr = 0;
+    } else {
+      emu.memory.writeU8(p, 0);
+      strtokPtr = p + 1;
+    }
+    return start;
+  });
+
+  // char *strerror(int errnum) — return pointer to static message
+  const strerrorBuf = emu.allocHeap(64);
+  emu.memory.writeCString(strerrorBuf, 'Unknown error');
+  msvcrt.register('strerror', 0, () => strerrorBuf);
+
+  // size_t strcspn(const char *s, const char *reject)
+  msvcrt.register('strcspn', 0, () => {
+    const s = emu.memory.readCString(emu.readArg(0));
+    const reject = emu.memory.readCString(emu.readArg(1));
+    const set = new Set(reject);
+    for (let i = 0; i < s.length; i++) if (set.has(s[i])) return i;
+    return s.length;
+  });
+
+  // size_t strspn(const char *s, const char *accept)
+  msvcrt.register('strspn', 0, () => {
+    const s = emu.memory.readCString(emu.readArg(0));
+    const accept = emu.memory.readCString(emu.readArg(1));
+    const set = new Set(accept);
+    for (let i = 0; i < s.length; i++) if (!set.has(s[i])) return i;
+    return s.length;
+  });
+
+  // char *strpbrk(const char *s, const char *accept)
+  msvcrt.register('strpbrk', 0, () => {
+    const sPtr = emu.readArg(0);
+    const s = emu.memory.readCString(sPtr);
+    const accept = emu.memory.readCString(emu.readArg(1));
+    const set = new Set(accept);
+    for (let i = 0; i < s.length; i++) if (set.has(s[i])) return sPtr + i;
+    return 0;
+  });
+
+  // void qsort(void *base, size_t nmemb, size_t size, int (*compar)(const void*, const void*))
+  msvcrt.register('qsort', 0, () => {
+    const base = emu.readArg(0);
+    const nmemb = emu.readArg(1);
+    const size = emu.readArg(2);
+    const compar = emu.readArg(3);
+    if (!base || nmemb < 2 || !size || !compar) return 0;
+
+    // Copy elements out to JS-owned buffers (so swapping in memory doesn't
+    // invalidate the comparator's view). We keep indices and sort them.
+    const buffers: Uint8Array[] = new Array(nmemb);
+    for (let i = 0; i < nmemb; i++) {
+      const buf = new Uint8Array(size);
+      for (let j = 0; j < size; j++) buf[j] = emu.memory.readU8(base + i * size + j);
+      buffers[i] = buf;
+    }
+
+    // Scratch slots for the comparator to read from — allocate once.
+    const slotA = emu.allocHeap(size);
+    const slotB = emu.allocHeap(size);
+    const writeSlot = (slot: number, buf: Uint8Array) => {
+      for (let j = 0; j < size; j++) emu.memory.writeU8(slot + j, buf[j]);
+    };
+
+    const indices = Array.from({ length: nmemb }, (_, i) => i);
+    indices.sort((a, b) => {
+      writeSlot(slotA, buffers[a]);
+      writeSlot(slotB, buffers[b]);
+      const r = emu.callCallback(compar, [slotA, slotB]) | 0;
+      return r;
+    });
+
+    // Write sorted data back
+    for (let i = 0; i < nmemb; i++) {
+      const src = buffers[indices[i]];
+      for (let j = 0; j < size; j++) emu.memory.writeU8(base + i * size + j, src[j]);
+    }
+    return 0;
+  });
+
+  // void perror(const char *s)
+  msvcrt.register('perror', 0, () => {
+    const s = emu.readArg(0) ? emu.memory.readCString(emu.readArg(0)) : '';
+    console.error(`[MSVCRT perror] ${s}${s ? ': ' : ''}<errno>`);
+    return 0;
+  });
+
+  // void *memchr(const void *s, int c, size_t n)
+  msvcrt.register('memchr', 0, () => {
+    const ptr = emu.readArg(0);
+    const c = emu.readArg(1) & 0xFF;
+    const n = emu.readArg(2);
+    for (let i = 0; i < n; i++) {
+      if (emu.memory.readU8(ptr + i) === c) return ptr + i;
+    }
+    return 0;
+  });
+
+  // char *strchr(const char *s, int c)
+  msvcrt.register('strchr', 0, () => {
+    const ptr = emu.readArg(0);
+    const c = emu.readArg(1) & 0xFF;
+    let p = ptr;
+    for (;;) {
+      const b = emu.memory.readU8(p);
+      if (b === c) return p;
+      if (b === 0) return 0;
+      p++;
+    }
+  });
+
   // atoi
   msvcrt.register('atoi', 0, () => {
     const str = emu.memory.readCString(emu.readArg(0));
     return parseInt(str, 10) || 0;
+  });
+
+  // atof(const char*) — returns double in ST(0)
+  msvcrt.register('atof', 0, () => {
+    const str = emu.memory.readCString(emu.readArg(0));
+    const v = parseFloat(str);
+    fpuPush(emu.cpu, isNaN(v) ? 0 : v);
+    return 0;
+  });
+
+  // strtod(const char *nptr, char **endptr)
+  msvcrt.register('strtod', 0, () => {
+    const nptr = emu.readArg(0);
+    const endptrPtr = emu.readArg(1);
+    const str = emu.memory.readCString(nptr);
+    const trimmed = str.replace(/^\s+/, '');
+    const leadingSpaces = str.length - trimmed.length;
+    const match = trimmed.match(/^[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?/);
+    let consumed = 0;
+    let v = 0;
+    if (match) { consumed = match[0].length; v = parseFloat(match[0]); }
+    if (endptrPtr) emu.memory.writeU32(endptrPtr, nptr + leadingSpaces + consumed);
+    fpuPush(emu.cpu, isNaN(v) ? 0 : v);
+    return 0;
   });
 
   // strtol / strtoul / wcstol

--- a/src/lib/emu/win32/opengl32.ts
+++ b/src/lib/emu/win32/opengl32.ts
@@ -148,7 +148,56 @@ export function registerOpengl32(emu: Emulator): void {
     const pname = emu.readArg(0);
     const ptr = emu.readArg(1);
     const gl = getGL(emu);
-    if (ptr) emu.memory.writeU32(ptr, gl ? gl.getIntegerv(pname) : 0);
+    if (!ptr) return 0;
+    if (pname === 0x0BA2 /* GL_VIEWPORT */) {
+      const vp = gl ? gl.getViewport() : [0, 0, 0, 0];
+      for (let i = 0; i < 4; i++) emu.memory.writeU32(ptr + i * 4, vp[i] | 0);
+    } else {
+      emu.memory.writeU32(ptr, gl ? gl.getIntegerv(pname) : 0);
+    }
+    return 0;
+  });
+
+  // glGetFloatv / glGetDoublev — mostly used to retrieve matrices
+  function writeMatrixFloats(ptr: number, m: Float32Array) {
+    const buf = new DataView(new ArrayBuffer(4));
+    for (let i = 0; i < 16; i++) {
+      buf.setFloat32(0, m[i], true);
+      emu.memory.writeU32(ptr + i * 4, buf.getUint32(0, true));
+    }
+  }
+  function writeMatrixDoubles(ptr: number, m: Float32Array) {
+    const buf = new DataView(new ArrayBuffer(8));
+    for (let i = 0; i < 16; i++) {
+      buf.setFloat64(0, m[i], true);
+      emu.memory.writeU32(ptr + i * 8, buf.getUint32(0, true));
+      emu.memory.writeU32(ptr + i * 8 + 4, buf.getUint32(4, true));
+    }
+  }
+  opengl32.register('glGetFloatv', 2, () => {
+    const pname = emu.readArg(0);
+    const ptr = emu.readArg(1);
+    const gl = getGL(emu);
+    if (!ptr || !gl) return 0;
+    const m = gl.getMatrix(pname);
+    if (m) writeMatrixFloats(ptr, m);
+    else if (pname === 0x0BA2 /* GL_VIEWPORT */) {
+      const vp = gl.getViewport();
+      const buf = new DataView(new ArrayBuffer(4));
+      for (let i = 0; i < 4; i++) {
+        buf.setFloat32(0, vp[i], true);
+        emu.memory.writeU32(ptr + i * 4, buf.getUint32(0, true));
+      }
+    }
+    return 0;
+  });
+  opengl32.register('glGetDoublev', 2, () => {
+    const pname = emu.readArg(0);
+    const ptr = emu.readArg(1);
+    const gl = getGL(emu);
+    if (!ptr || !gl) return 0;
+    const m = gl.getMatrix(pname);
+    if (m) writeMatrixDoubles(ptr, m);
     return 0;
   });
 
@@ -418,6 +467,98 @@ export function registerOpengl32(emu: Emulator): void {
     return 0;
   });
 
+  opengl32.register('glColor4f', 4, () => {
+    getGL(emu)?.color4f(readFloat(emu, 0), readFloat(emu, 1), readFloat(emu, 2), readFloat(emu, 3));
+    return 0;
+  });
+
+  opengl32.register('glColorMask', 4, () => {
+    getGL(emu)?.colorMask(!!emu.readArg(0), !!emu.readArg(1), !!emu.readArg(2), !!emu.readArg(3));
+    return 0;
+  });
+  opengl32.register('glDepthMask', 1, () => { getGL(emu)?.depthMask(!!emu.readArg(0)); return 0; });
+  opengl32.register('glStencilMask', 1, () => { getGL(emu)?.stencilMask(emu.readArg(0)); return 0; });
+  opengl32.register('glStencilFunc', 3, () => {
+    getGL(emu)?.stencilFunc(emu.readArg(0), emu.readArg(1) | 0, emu.readArg(2));
+    return 0;
+  });
+  opengl32.register('glStencilOp', 3, () => {
+    getGL(emu)?.stencilOp(emu.readArg(0), emu.readArg(1), emu.readArg(2));
+    return 0;
+  });
+  opengl32.register('glClearStencil', 1, () => { getGL(emu)?.clearStencil(emu.readArg(0) | 0); return 0; });
+  opengl32.register('glPolygonOffset', 2, () => {
+    getGL(emu)?.polygonOffset(readFloat(emu, 0), readFloat(emu, 1));
+    return 0;
+  });
+
+  // glColorMaterial(face, mode) — our shader treats glColor as the material color
+  // already, so this is effectively a no-op. Just accept the call.
+  opengl32.register('glColorMaterial', 2, () => 0);
+
+  // Fog — accept but don't implement (demos typically work fine without fog in WebGL)
+  opengl32.register('glFogf', 2, () => 0);
+  opengl32.register('glFogi', 2, () => 0);
+  opengl32.register('glFogfv', 2, () => 0);
+  opengl32.register('glFogiv', 2, () => 0);
+
+  // Attribute stack — no-op stubs (WebGL doesn't have server-side attrib stacks)
+  opengl32.register('glPushAttrib', 1, () => 0);
+  opengl32.register('glPopAttrib', 0, () => 0);
+  opengl32.register('glPushClientAttrib', 1, () => 0);
+  opengl32.register('glPopClientAttrib', 0, () => 0);
+
+  // TexGen — not available in WebGL2 core. Accept calls so sphere mapping etc.
+  // doesn't crash; the texcoords will simply not be generated automatically.
+  opengl32.register('glTexGeni', 3, () => 0);
+  opengl32.register('glTexGenf', 3, () => 0);
+  opengl32.register('glTexGend', 4, () => 0);
+  opengl32.register('glTexGenfv', 3, () => 0);
+  opengl32.register('glTexGeniv', 3, () => 0);
+  opengl32.register('glTexGendv', 3, () => 0);
+
+  // ReadPixels / CopyTexImage — used for screen-space effects.
+  // Stub: leave destination unchanged (caller sees garbage or zeros).
+  opengl32.register('glReadPixels', 7, () => 0);
+  opengl32.register('glReadBuffer', 1, () => 0);
+  opengl32.register('glDrawBuffer', 1, () => 0);
+  opengl32.register('glCopyTexImage2D', 8, () => 0);
+  opengl32.register('glCopyTexSubImage2D', 8, () => 0);
+  opengl32.register('glCopyPixels', 5, () => 0);
+  opengl32.register('glPixelTransferf', 2, () => 0);
+  opengl32.register('glPixelTransferi', 2, () => 0);
+  opengl32.register('glPixelZoom', 2, () => 0);
+
+  // Accumulation buffer — not supported, noop.
+  opengl32.register('glAccum', 2, () => 0);
+  opengl32.register('glClearAccum', 4, () => 0);
+
+  // Raster position / DrawPixels — rarely critical, noop.
+  opengl32.register('glRasterPos2i', 2, () => 0);
+  opengl32.register('glRasterPos2f', 2, () => 0);
+  opengl32.register('glRasterPos3f', 3, () => 0);
+  opengl32.register('glRasterPos3fv', 1, () => 0);
+  opengl32.register('glRasterPos4fv', 1, () => 0);
+  opengl32.register('glWindowPos2i', 2, () => 0);
+  opengl32.register('glWindowPos2f', 2, () => 0);
+  opengl32.register('glDrawPixels', 5, () => 0);
+  opengl32.register('glBitmap', 7, () => 0);
+
+  // Clip planes — noop (not supported by our shader).
+  opengl32.register('glClipPlane', 2, () => 0);
+
+  // Point & line attributes — noop (WebGL only has default sizes).
+  opengl32.register('glPointSize', 1, () => 0);
+  opengl32.register('glLineWidth', 1, () => 0);
+  opengl32.register('glLineStipple', 2, () => 0);
+  opengl32.register('glPolygonStipple', 1, () => 0);
+
+  // Error reporting — always return GL_NO_ERROR (0).
+  opengl32.register('glGetError', 0, () => 0);
+
+  // Edge flags — ignored.
+  opengl32.register('glEdgeFlag', 1, () => 0);
+
   opengl32.register('glColor4fv', 1, () => {
     const ptr = emu.readArg(0);
     const v = readFloatPtr(emu, ptr, 4);
@@ -544,6 +685,67 @@ export function registerOpengl32(emu: Emulator): void {
     naPtr = emu.readArg(2);
     return 0;
   });
+
+  // Texture coord array — tracked but only consumed by our glDrawArrays/Elements emulation
+  let taSize = 2, taStride = 0, taPtr = 0;
+  let caSize = 4, caStride = 0, caPtr = 0;
+  opengl32.register('glTexCoordPointer', 4, () => {
+    taSize = emu.readArg(0);
+    taStride = emu.readArg(2);
+    taPtr = emu.readArg(3);
+    return 0;
+  });
+  opengl32.register('glColorPointer', 4, () => {
+    caSize = emu.readArg(0);
+    caStride = emu.readArg(2);
+    caPtr = emu.readArg(3);
+    return 0;
+  });
+  void taSize; void taStride; void taPtr;
+  void caSize; void caStride; void caPtr;
+  // glArrayElement(i) — emit vertex i from the enabled vertex arrays.
+  // Minimal: read the vertex from glVertexPointer buffer and push it via glVertex3f/2f.
+  opengl32.register('glArrayElement', 1, () => {
+    const gl = getGL(emu);
+    if (!gl || !vaPtr) return 0;
+    const i = emu.readArg(0);
+    const stride = vaStride || vaSize * 4;
+    const base = vaPtr + i * stride;
+    const v = readFloatPtr(emu, base, vaSize);
+    if (naPtr) {
+      const nStride = naStride || 12;
+      const n = readFloatPtr(emu, naPtr + i * nStride, 3);
+      gl.normal3f(n[0], n[1], n[2]);
+    }
+    if (vaSize >= 3) gl.vertex3f(v[0], v[1], v[2]);
+    else gl.vertex2f(v[0], v[1]);
+    return 0;
+  });
+
+  // glDrawArrays(mode, first, count) — draw count vertices starting from `first`
+  opengl32.register('glDrawArrays', 3, () => {
+    const gl = getGL(emu);
+    if (!gl || !vaPtr) return 0;
+    const mode = emu.readArg(0);
+    const first = emu.readArg(1);
+    const count = emu.readArg(2);
+    const stride = vaStride || vaSize * 4;
+    gl.begin(mode);
+    for (let i = 0; i < count; i++) {
+      const base = vaPtr + (first + i) * stride;
+      const v = readFloatPtr(emu, base, vaSize);
+      if (naPtr) {
+        const nStride = naStride || 12;
+        const n = readFloatPtr(emu, naPtr + (first + i) * nStride, 3);
+        gl.normal3f(n[0], n[1], n[2]);
+      }
+      if (vaSize >= 3) gl.vertex3f(v[0], v[1], v[2]);
+      else gl.vertex2f(v[0], v[1]);
+    }
+    gl.end();
+    return 0;
+  });
+
   opengl32.register('glDrawElements', 4, () => {
     const gl = getGL(emu);
     if (!gl) return 0;

--- a/src/lib/emu/win32/user32/dialog.ts
+++ b/src/lib/emu/win32/user32/dialog.ts
@@ -64,6 +64,22 @@ export function registerDialog(emu: Emulator): void {
       : allDialogs.find(d => d.id === templateId);
     if (mainResult) return mainResult.dialog;
 
+    // Fallback: read the main exe's resource directory from emulator memory.
+    // This is needed for UPX-packed executables where the resource data in the
+    // raw file is compressed but has been decompressed in memory at runtime.
+    try {
+      const entry = emu.findResourceEntry(5 /* RT_DIALOG */, templateId);
+      if (entry) {
+        const addr = emu.pe.imageBase + entry.dataRva;
+        const buf = new ArrayBuffer(entry.dataSize);
+        const u8 = new Uint8Array(buf);
+        for (let i = 0; i < entry.dataSize; i++) u8[i] = emu.memory.readU8(addr + i);
+        return parseDialogTemplate(buf, 0, entry.dataSize);
+      }
+    } catch (e: unknown) {
+      console.warn(`[DLG] Failed to parse main-exe dialog template ${templateId} from memory: ${e instanceof Error ? e.message : String(e)}`);
+    }
+
     // Check loaded DLL modules by hInstance
     for (const [, mod] of emu.loadedModules) {
       if (mod.imageBase !== hInstance && mod.base !== hInstance) continue;

--- a/src/lib/emu/win32/user32/misc.ts
+++ b/src/lib/emu/win32/user32/misc.ts
@@ -405,8 +405,50 @@ export function registerMisc(emu: Emulator): void {
 
   user32.register('FindWindowA', 2, () => 0); // not found
   user32.register('FindWindowExA', 4, () => 0); // not found
-  user32.register('EnumDisplaySettingsA', 3, () => 0); // fail
-  user32.register('EnumDisplaySettingsW', 3, () => 0); // fail
+  // Common resolutions reported at 16bpp and 32bpp, 60Hz. Windows reports
+  // many modes; the demo's config dialog filters to >8bpp and picks 640x480.
+  const COMMON_MODES: [number, number][] = [
+    [640, 480], [800, 600], [1024, 768], [1152, 864],
+    [1280, 720], [1280, 800], [1280, 960], [1280, 1024],
+    [1366, 768], [1440, 900], [1600, 900], [1600, 1200],
+    [1680, 1050], [1920, 1080], [1920, 1200],
+  ];
+  const BPPS = [16, 32];
+  function fillDevmode(lpDevMode: number, w: number, h: number, bpp: number): void {
+    if (!lpDevMode) return;
+    for (let i = 0; i < 156; i += 4) emu.memory.writeU32(lpDevMode + i, 0);
+    emu.memory.writeU16(lpDevMode + 36, 156); // dmSize
+    // dmFields: DM_BITSPERPEL | DM_PELSWIDTH | DM_PELSHEIGHT | DM_DISPLAYFREQUENCY
+    emu.memory.writeU32(lpDevMode + 40, 0x00040000 | 0x00080000 | 0x00100000 | 0x00400000);
+    emu.memory.writeU32(lpDevMode + 104, bpp);
+    emu.memory.writeU32(lpDevMode + 108, w);
+    emu.memory.writeU32(lpDevMode + 112, h);
+    emu.memory.writeU32(lpDevMode + 120, 60);
+  }
+  function pickMode(iModeNum: number): { w: number; h: number; bpp: number } | null {
+    if (iModeNum === -1) return { w: emu.screenWidth, h: emu.screenHeight, bpp: 32 };
+    // Build a mode list: each (w, h) paired with each BPP, ending with the native resolution.
+    const modes: { w: number; h: number; bpp: number }[] = [];
+    for (const [w, h] of COMMON_MODES) {
+      if (w > emu.screenWidth || h > emu.screenHeight) continue;
+      for (const bpp of BPPS) modes.push({ w, h, bpp });
+    }
+    // Append the native resolution at 32bpp if not already listed.
+    const hasNative = modes.some(m => m.w === emu.screenWidth && m.h === emu.screenHeight);
+    if (!hasNative) modes.push({ w: emu.screenWidth, h: emu.screenHeight, bpp: 32 });
+    if (iModeNum < 0 || iModeNum >= modes.length) return null;
+    return modes[iModeNum];
+  }
+  const enumDisplay = () => {
+    const iModeNum = emu.readArg(1) | 0;
+    const lpDevMode = emu.readArg(2);
+    const m = pickMode(iModeNum);
+    if (!m) return 0;
+    fillDevmode(lpDevMode, m.w, m.h, m.bpp);
+    return 1;
+  };
+  user32.register('EnumDisplaySettingsA', 3, enumDisplay);
+  user32.register('EnumDisplaySettingsW', 3, enumDisplay);
 
   // EnumDisplayDevicesA(lpDevice, iDevNum, lpDisplayDevice, dwFlags) → BOOL
   user32.register('EnumDisplayDevicesA', 4, () => {

--- a/src/lib/emu/x86/fpu-dcdf.ts
+++ b/src/lib/emu/x86/fpu-dcdf.ts
@@ -130,10 +130,14 @@ export function execFPU_DC(cpu: CPU, mod: number, regField: number, rm: number, 
       case 1: fpuSetST(cpu, rm, fpuST(cpu, rm) * fpuST(cpu, 0)); break;
       case 2: fpuCompare(cpu, fpuST(cpu, 0), fpuST(cpu, rm)); break;
       case 3: fpuCompare(cpu, fpuST(cpu, 0), fpuST(cpu, rm)); fpuPop(cpu); break;
-      case 4: fpuSetST(cpu, rm, fpuST(cpu, rm) - fpuST(cpu, 0)); break;
-      case 5: fpuSetST(cpu, rm, fpuST(cpu, 0) - fpuST(cpu, rm)); break;
-      case 6: fpuSetST(cpu, rm, fpuST(cpu, rm) / fpuST(cpu, 0)); break;
-      case 7: fpuSetST(cpu, rm, fpuST(cpu, 0) / fpuST(cpu, rm)); break;
+      // DC E0+i (/4) = FSUBR ST(i), ST(0) : ST(i) = ST(0) - ST(i)
+      case 4: fpuSetST(cpu, rm, fpuST(cpu, 0) - fpuST(cpu, rm)); break;
+      // DC E8+i (/5) = FSUB  ST(i), ST(0) : ST(i) = ST(i) - ST(0)
+      case 5: fpuSetST(cpu, rm, fpuST(cpu, rm) - fpuST(cpu, 0)); break;
+      // DC F0+i (/6) = FDIVR ST(i), ST(0) : ST(i) = ST(0) / ST(i)
+      case 6: fpuSetST(cpu, rm, fpuST(cpu, 0) / fpuST(cpu, rm)); break;
+      // DC F8+i (/7) = FDIV  ST(i), ST(0) : ST(i) = ST(i) / ST(0)
+      case 7: fpuSetST(cpu, rm, fpuST(cpu, rm) / fpuST(cpu, 0)); break;
     }
   }
 }
@@ -218,10 +222,14 @@ export function execFPU_DE(cpu: CPU, mod: number, regField: number, rm: number, 
           fpuPop(cpu);
         }
         break;
-      case 4: fpuSetST(cpu, rm, fpuST(cpu, rm) - fpuST(cpu, 0)); fpuPop(cpu); break;
-      case 5: fpuSetST(cpu, rm, fpuST(cpu, 0) - fpuST(cpu, rm)); fpuPop(cpu); break;
-      case 6: fpuSetST(cpu, rm, fpuST(cpu, rm) / fpuST(cpu, 0)); fpuPop(cpu); break;
-      case 7: fpuSetST(cpu, rm, fpuST(cpu, 0) / fpuST(cpu, rm)); fpuPop(cpu); break;
+      // DE E0+i (/4) = FSUBRP ST(i), ST(0) : ST(i) = ST(0) - ST(i); pop
+      case 4: fpuSetST(cpu, rm, fpuST(cpu, 0) - fpuST(cpu, rm)); fpuPop(cpu); break;
+      // DE E8+i (/5) = FSUBP  ST(i), ST(0) : ST(i) = ST(i) - ST(0); pop
+      case 5: fpuSetST(cpu, rm, fpuST(cpu, rm) - fpuST(cpu, 0)); fpuPop(cpu); break;
+      // DE F0+i (/6) = FDIVRP ST(i), ST(0) : ST(i) = ST(0) / ST(i); pop
+      case 6: fpuSetST(cpu, rm, fpuST(cpu, 0) / fpuST(cpu, rm)); fpuPop(cpu); break;
+      // DE F8+i (/7) = FDIVP  ST(i), ST(0) : ST(i) = ST(i) / ST(0); pop
+      case 7: fpuSetST(cpu, rm, fpuST(cpu, rm) / fpuST(cpu, 0)); fpuPop(cpu); break;
     }
   }
 }

--- a/tests/inspect-demo-dat.mjs
+++ b/tests/inspect-demo-dat.mjs
@@ -1,0 +1,33 @@
+import { readFileSync } from 'fs';
+const b = readFileSync('C:/Users/Olivier/Downloads/e_amoeba-final/e_amoeba-final/demo.dat');
+console.log('Size:', b.length);
+
+// Parse PACK header
+const dirpos = b.readUInt32LE(4);
+const dirsize = b.readUInt32LE(8);
+console.log('dirpos:', dirpos, 'dirsize:', dirsize);
+
+// Each pak_direntry is {char filename[56]; int pos; int size;} = 64 bytes
+const entrySize = 64;
+const entries = [];
+for (let i = 0; i < dirsize / entrySize; i++) {
+  const off = dirpos + i * entrySize;
+  const name = b.slice(off, off + 56).toString('ascii').split('\0')[0];
+  const pos = b.readUInt32LE(off + 56);
+  const size = b.readUInt32LE(off + 60);
+  entries.push({ name, pos, size });
+}
+console.log(`Entries: ${entries.length}`);
+const ogg = entries.find(e => e.name === 'data/amoeba-test.ogg');
+if (ogg) {
+  console.log(`\nOGG file: pos=0x${ogg.pos.toString(16)} size=${ogg.size}`);
+  console.log('First 64 bytes:', [...b.slice(ogg.pos, ogg.pos + 64)].map(x => x.toString(16).padStart(2, '0')).join(' '));
+  // Check Vorbis identification header: should be \x01vorbis (7 bytes) at some offset inside the first Ogg page
+  for (let i = ogg.pos; i < ogg.pos + 200; i++) {
+    if (b[i] === 0x01 && b.slice(i + 1, i + 7).toString('ascii') === 'vorbis') {
+      console.log(`\\x01vorbis header at Ogg-offset ${i - ogg.pos}`);
+      console.log('Vorbis ID header bytes:', [...b.slice(i, i + 30)].map(x => x.toString(16).padStart(2, '0')).join(' '));
+      break;
+    }
+  }
+}

--- a/tests/inspect-dialog.mjs
+++ b/tests/inspect-dialog.mjs
@@ -1,0 +1,27 @@
+import { readFileSync } from 'fs';
+import { parsePE } from '../src/lib/pe/index.ts';
+import { rvaToFileOffset } from '../src/lib/pe/read.ts';
+
+const b = readFileSync('C:/Users/Olivier/Downloads/e_amoeba-final/e_amoeba-final/demo-win32.exe');
+const ab = new ArrayBuffer(b.byteLength);
+new Uint8Array(ab).set(b);
+const pe = parsePE(ab);
+
+const dlgType = pe.resources?.find(r => r.typeId === 5);
+if (!dlgType) { console.log('No dialog resources'); process.exit(0); }
+
+for (const entry of dlgType.entries) {
+  for (const lang of entry.languages) {
+    const off = rvaToFileOffset(lang.dataRva, pe.sections);
+    console.log(`Dialog ${entry.id ?? entry.name} lang=${lang.languageId} RVA=0x${lang.dataRva.toString(16)} fileOff=0x${off.toString(16)} size=${lang.dataSize}`);
+    const dv = new DataView(ab, off, lang.dataSize);
+    const sig0 = dv.getUint16(0, true);
+    const sig1 = dv.getUint16(2, true);
+    console.log(`  sig0=0x${sig0.toString(16)} sig1=0x${sig1.toString(16)} (isEx = ${sig0 === 1 && sig1 === 0xFFFF})`);
+    console.log(`  First 32 bytes:`, [...new Uint8Array(ab, off, Math.min(32, lang.dataSize))].map(x => x.toString(16).padStart(2, '0')).join(' '));
+    const buf = new Uint8Array(ab, off, lang.dataSize);
+    const asc = Array.from(buf).map(b => (b >= 0x20 && b < 0x7F) ? String.fromCharCode(b) : '.').join('');
+    console.log(`  ASCII dump:`);
+    for (let i = 0; i < asc.length; i += 64) console.log('    ', asc.slice(i, i + 64));
+  }
+}

--- a/tests/inspect-pe.mjs
+++ b/tests/inspect-pe.mjs
@@ -1,0 +1,21 @@
+import { readFileSync } from 'fs';
+const b = readFileSync('C:/Users/Olivier/Downloads/e_amoeba-final/e_amoeba-final/demo-win32.exe');
+// Look at section names
+const peOff = b.readUInt32LE(0x3c);
+const numSections = b.readUInt16LE(peOff + 6);
+const sizeOfOptHdr = b.readUInt16LE(peOff + 20);
+const sectHdrOff = peOff + 24 + sizeOfOptHdr;
+console.log(`Sections (${numSections}):`);
+for (let i = 0; i < numSections; i++) {
+  const off = sectHdrOff + i * 40;
+  const name = b.slice(off, off + 8).toString('ascii').replace(/\0.*/, '');
+  const vsize = b.readUInt32LE(off + 8);
+  const vaddr = b.readUInt32LE(off + 12);
+  const rsize = b.readUInt32LE(off + 16);
+  const raddr = b.readUInt32LE(off + 20);
+  const flags = b.readUInt32LE(off + 36);
+  console.log(`  ${name.padEnd(10)} vaddr=0x${vaddr.toString(16).padStart(6,'0')} vsize=0x${vsize.toString(16).padStart(6,'0')} raddr=0x${raddr.toString(16).padStart(6,'0')} rsize=0x${rsize.toString(16).padStart(6,'0')} flags=0x${flags.toString(16)}`);
+}
+// UPX signature search
+const upxSig = b.includes(Buffer.from('UPX!'));
+console.log('Contains "UPX!":', upxSig);

--- a/tests/list-amoeba-imports.mjs
+++ b/tests/list-amoeba-imports.mjs
@@ -1,0 +1,13 @@
+import { readFileSync } from 'fs';
+import { parsePE } from '../src/lib/pe/index.ts';
+import { extractImports } from '../src/lib/pe/extract-import.ts';
+
+const b = readFileSync('C:/Users/Olivier/Downloads/e_amoeba-final/e_amoeba-final/demo-win32.exe');
+const ab = new ArrayBuffer(b.byteLength);
+new Uint8Array(ab).set(b);
+const pe = parsePE(ab);
+const imports = extractImports(pe, ab);
+for (const imp of imports) {
+  console.log(`\n=== ${imp.dllName} ===`);
+  for (const fn of imp.functions) console.log(`  ${fn.name || '#' + fn.ordinal}`);
+}

--- a/tests/test-amoeba.mjs
+++ b/tests/test-amoeba.mjs
@@ -62,15 +62,22 @@ emu.screenHeight = 600;
 emu.registryStore = new RegistryStore();
 emu.profileStore = new ProfileStore();
 
-// Capture console output for missing API detection
+// Capture console output for missing API detection + Ogg error trigger
 const notFound = new Set();
+let sawOggError = false;
 const origWarn = console.warn.bind(console);
 const origLog = console.log.bind(console);
 console.log = (...args) => {
   const s = args.join(' ');
   const m = s.match(/\[GetProcAddress\] Not found: "([^"]+)"/);
   if (m) notFound.add(m[1]);
+  if (s.includes('Ogg bitstream')) sawOggError = true;
   origLog(...args);
+};
+console.error = (...args) => {
+  const s = args.join(' ');
+  if (s.includes('Ogg bitstream')) sawOggError = true;
+  origWarn(...args);
 };
 
 // Copy demo.dat into the emulator's virtual filesystem so the demo can open it
@@ -80,22 +87,30 @@ emu.additionalFiles.set('demo.dat', demoDatBytes.buffer.slice(demoDatBytes.byteO
 await emu.load(realArrayBuffer, peInfo, mockCanvas);
 emu.run();
 
+// Auto-dismiss config dialog with IDC_OK (1001) to exercise the post-dialog path.
+const IDC_OK = 1001;
+let dismissedDialogs = 0;
+
 const MAX_TICKS = 5_000_000;
 let ticks = 0;
 let stuckCount = 0;
 let lastEip = 0;
-let waitCount = 0;
-while (!emu.halted && ticks < MAX_TICKS) {
-  if (emu.waitingForMessage) {
-    // Feed an idle message so main loop keeps running
-    emu.waitingForMessage = false;
-    waitCount++;
-    if (waitCount > 1000) break;
+while (!emu.halted && ticks < MAX_TICKS && !sawOggError) {
+  if (emu.dialogState && !emu.dialogState.ended) {
+    dismissedDialogs++;
+    console.log(`[TEST] dismiss dialog #${dismissedDialogs}`);
+    emu.dismissDialog(IDC_OK, new Map());
+    // _endDialog schedules the thunk completion via queueMicrotask —
+    // yield to drain microtasks so the DialogBoxParam call actually returns.
+    await Promise.resolve();
+    continue;
   }
+  if (emu.waitingForMessage) emu.waitingForMessage = false;
   emu.tick();
   ticks++;
   if (emu.cpu.eip === lastEip) stuckCount++; else { stuckCount = 0; lastEip = emu.cpu.eip; }
-  if (stuckCount > 500) break;
+  if (stuckCount > 5000) break;
+  if (dismissedDialogs > 5) break;
 }
 
 console.log(`\n[TEST] ticks=${ticks} waiting=${emu.waitingForMessage} halted=${emu.halted} reason=${emu.cpu.haltReason || 'none'}`);

--- a/tests/test-amoeba.mjs
+++ b/tests/test-amoeba.mjs
@@ -1,0 +1,114 @@
+import { readFileSync } from 'fs';
+import { Emulator } from '../src/lib/emu/emulator.ts';
+import { parsePE } from '../src/lib/pe/index.ts';
+import { RegistryStore } from '../src/lib/registry-store.ts';
+import { ProfileStore } from '../src/lib/profile-store.ts';
+
+const noop = () => {};
+const mockCtx = {
+  fillRect: noop, clearRect: noop, strokeRect: noop,
+  fillText: noop, strokeText: noop, measureText: () => ({ width: 8 }),
+  drawImage: noop, putImageData: noop, getImageData: () => ({ data: new Uint8ClampedArray(4) }),
+  createImageData: (w, h) => ({ data: new Uint8ClampedArray(w * h * 4), width: w, height: h }),
+  save: noop, restore: noop, translate: noop, scale: noop, rotate: noop,
+  setTransform: noop, resetTransform: noop, transform: noop,
+  beginPath: noop, closePath: noop, moveTo: noop, lineTo: noop,
+  arc: noop, arcTo: noop, rect: noop, ellipse: noop,
+  fill: noop, stroke: noop, clip: noop,
+  createLinearGradient: () => ({ addColorStop: noop }),
+  createRadialGradient: () => ({ addColorStop: noop }),
+  createPattern: () => null,
+  font: '', textAlign: 'left', textBaseline: 'top',
+  fillStyle: '', strokeStyle: '', lineWidth: 1, lineCap: 'butt', lineJoin: 'miter',
+  globalAlpha: 1, globalCompositeOperation: 'source-over',
+  imageSmoothingEnabled: true, shadowBlur: 0, shadowColor: 'transparent',
+  canvas: null,
+};
+const mockCanvas = {
+  width: 800, height: 600,
+  getContext: () => mockCtx,
+  toDataURL: () => 'data:image/png;base64,',
+  addEventListener: noop,
+  removeEventListener: noop,
+  style: { cursor: 'default' },
+  parentElement: { style: { cursor: 'default' } },
+};
+mockCtx.canvas = mockCanvas;
+
+globalThis.document = { createElement: () => mockCanvas, title: '' };
+globalThis.OffscreenCanvas = class {
+  constructor(w, h) { this.width = w; this.height = h; }
+  getContext() { return { ...mockCtx, canvas: this }; }
+};
+globalThis.requestAnimationFrame = (cb) => setTimeout(cb, 0);
+globalThis.Image = class { set src(_) {} };
+globalThis.URL = { createObjectURL: () => 'blob:mock', revokeObjectURL: noop };
+globalThis.Blob = class { constructor() {} };
+
+function readToArrayBuffer(path) {
+  const b = readFileSync(path);
+  const ab = new ArrayBuffer(b.byteLength);
+  new Uint8Array(ab).set(b);
+  return ab;
+}
+
+const EXE_PATH = 'C:/Users/Olivier/Downloads/e_amoeba-final/e_amoeba-final/demo-win32.exe';
+const realArrayBuffer = readToArrayBuffer(EXE_PATH);
+const peInfo = parsePE(realArrayBuffer);
+
+const emu = new Emulator();
+emu.screenWidth = 800;
+emu.screenHeight = 600;
+emu.registryStore = new RegistryStore();
+emu.profileStore = new ProfileStore();
+
+// Capture console output for missing API detection
+const notFound = new Set();
+const origWarn = console.warn.bind(console);
+const origLog = console.log.bind(console);
+console.log = (...args) => {
+  const s = args.join(' ');
+  const m = s.match(/\[GetProcAddress\] Not found: "([^"]+)"/);
+  if (m) notFound.add(m[1]);
+  origLog(...args);
+};
+
+// Copy demo.dat into the emulator's virtual filesystem so the demo can open it
+const demoDatBytes = readFileSync('C:/Users/Olivier/Downloads/e_amoeba-final/e_amoeba-final/demo.dat');
+emu.additionalFiles.set('demo.dat', demoDatBytes.buffer.slice(demoDatBytes.byteOffset, demoDatBytes.byteOffset + demoDatBytes.byteLength));
+
+await emu.load(realArrayBuffer, peInfo, mockCanvas);
+emu.run();
+
+const MAX_TICKS = 5_000_000;
+let ticks = 0;
+let stuckCount = 0;
+let lastEip = 0;
+let waitCount = 0;
+while (!emu.halted && ticks < MAX_TICKS) {
+  if (emu.waitingForMessage) {
+    // Feed an idle message so main loop keeps running
+    emu.waitingForMessage = false;
+    waitCount++;
+    if (waitCount > 1000) break;
+  }
+  emu.tick();
+  ticks++;
+  if (emu.cpu.eip === lastEip) stuckCount++; else { stuckCount = 0; lastEip = emu.cpu.eip; }
+  if (stuckCount > 500) break;
+}
+
+console.log(`\n[TEST] ticks=${ticks} waiting=${emu.waitingForMessage} halted=${emu.halted} reason=${emu.cpu.haltReason || 'none'}`);
+console.log(`[TEST] Missing APIs: ${notFound.size}`);
+for (const name of notFound) console.log(`  - ${name}`);
+
+if (emu.waitingForMessage) {
+  console.log('[TEST] SUCCESS: Reached message loop');
+  process.exit(0);
+} else if (emu.halted) {
+  console.log('[TEST] HALTED');
+  process.exit(1);
+} else {
+  console.log('[TEST] TIMEOUT or stuck');
+  process.exit(1);
+}

--- a/tests/test-amoeba.mjs
+++ b/tests/test-amoeba.mjs
@@ -62,9 +62,9 @@ emu.screenHeight = 600;
 emu.registryStore = new RegistryStore();
 emu.profileStore = new ProfileStore();
 
-// Capture console output for missing API detection + Ogg error trigger
 const notFound = new Set();
 let sawOggError = false;
+let firstMsgBoxText = null, firstMsgBoxCaption = null;
 const origWarn = console.warn.bind(console);
 const origLog = console.log.bind(console);
 console.log = (...args) => {
@@ -80,50 +80,78 @@ console.error = (...args) => {
   origWarn(...args);
 };
 
-// Copy demo.dat into the emulator's virtual filesystem so the demo can open it
 const demoDatBytes = readFileSync('C:/Users/Olivier/Downloads/e_amoeba-final/e_amoeba-final/demo.dat');
 emu.additionalFiles.set('demo.dat', demoDatBytes.buffer.slice(demoDatBytes.byteOffset, demoDatBytes.byteOffset + demoDatBytes.byteLength));
 
 await emu.load(realArrayBuffer, peInfo, mockCanvas);
+
+// Headless-only overrides: Sleep and PeekMessage normally suspend via async rAF
+// callbacks that a synchronous test loop cannot service, so bypass them. MessageBoxA
+// is auto-dismissed and its text captured so the test can assert no demo error fired.
+emu.apiDefs.set('KERNEL32.DLL:Sleep', { handler: () => 0, stackBytes: 4 });
+const realPeek = emu.apiDefs.get('USER32.DLL:PeekMessageA')?.handler;
+emu.apiDefs.set('USER32.DLL:PeekMessageA', {
+  handler: () => {
+    const wasWaiting = emu.waitingForMessage;
+    const r = realPeek(emu);
+    if (r === undefined) { emu.waitingForMessage = wasWaiting; return 0; }
+    return r;
+  },
+  stackBytes: 20,
+});
+emu.apiDefs.set('USER32.DLL:MessageBoxA', {
+  handler: () => {
+    if (firstMsgBoxText === null) {
+      const textPtr = emu.readArg(1);
+      const captionPtr = emu.readArg(2);
+      firstMsgBoxText = textPtr ? emu.memory.readCString(textPtr, 256) : '<null>';
+      firstMsgBoxCaption = captionPtr ? emu.memory.readCString(captionPtr, 64) : '<null>';
+    }
+    return 1;
+  },
+  stackBytes: 16,
+});
+
 emu.run();
 
-// Auto-dismiss config dialog with IDC_OK (1001) to exercise the post-dialog path.
 const IDC_OK = 1001;
 let dismissedDialogs = 0;
-
 const MAX_TICKS = 5_000_000;
 let ticks = 0;
 let stuckCount = 0;
 let lastEip = 0;
+let reachedMsgLoop = false;
 while (!emu.halted && ticks < MAX_TICKS && !sawOggError) {
   if (emu.dialogState && !emu.dialogState.ended) {
     dismissedDialogs++;
     console.log(`[TEST] dismiss dialog #${dismissedDialogs}`);
     emu.dismissDialog(IDC_OK, new Map());
-    // _endDialog schedules the thunk completion via queueMicrotask —
-    // yield to drain microtasks so the DialogBoxParam call actually returns.
     await Promise.resolve();
     continue;
   }
-  if (emu.waitingForMessage) emu.waitingForMessage = false;
+  if (emu.waitingForMessage) { reachedMsgLoop = true; emu.waitingForMessage = false; }
   emu.tick();
   ticks++;
   if (emu.cpu.eip === lastEip) stuckCount++; else { stuckCount = 0; lastEip = emu.cpu.eip; }
   if (stuckCount > 5000) break;
   if (dismissedDialogs > 5) break;
+  if (reachedMsgLoop && ticks > 50_000) break;
 }
 
-console.log(`\n[TEST] ticks=${ticks} waiting=${emu.waitingForMessage} halted=${emu.halted} reason=${emu.cpu.haltReason || 'none'}`);
+console.log(`\n[TEST] ticks=${ticks} reachedMsgLoop=${reachedMsgLoop} halted=${emu.halted} reason=${emu.cpu.haltReason || 'none'}`);
 console.log(`[TEST] Missing APIs: ${notFound.size}`);
 for (const name of notFound) console.log(`  - ${name}`);
+if (firstMsgBoxText !== null) {
+  console.log(`[TEST] MessageBoxA fired: caption="${firstMsgBoxCaption}" text="${firstMsgBoxText}"`);
+}
 
-if (emu.waitingForMessage) {
-  console.log('[TEST] SUCCESS: Reached message loop');
-  process.exit(0);
-} else if (emu.halted) {
-  console.log('[TEST] HALTED');
-  process.exit(1);
-} else {
-  console.log('[TEST] TIMEOUT or stuck');
+if (!reachedMsgLoop) {
+  console.log('[TEST] FAIL: did not reach message loop');
   process.exit(1);
 }
+if (firstMsgBoxText !== null) {
+  console.log('[TEST] FAIL: demo reported an error');
+  process.exit(1);
+}
+console.log('[TEST] SUCCESS: reached message loop, no demo error');
+process.exit(0);


### PR DESCRIPTION

  ## Summary

  A batch of emulator fixes found while trying to run the amoeba demo. The demo
  itself **does not run yet** — these are independent gaps the work surfaced, each
  worth landing on its own. None of them are app-specific: they fix real bugs or
  missing API behavior that any PE hitting the same paths would trip on.

  ### Emulator fixes

  - **PE / UPX resources**: read resources from UPX-packed executables, and add the
    parsing pieces amoeba needs to load at all (commit `bd93ca9`).
  - **ComboBox dropdown clipping**: render the dropdown through a portal so it can
    escape its parent window's clipping rect (commit `651eb38`).
  - **DirectSound device enumeration**: actually enumerate output devices so apps
    populating a sound-picker dialog see at least the default device (commit
    `fbd43ac`).
  - **FPU operand order**: `FDIVP` was swapped with `FDIVRP`, and `FSUBP` with
    `FSUBRP`. The reversed pair was dividing / subtracting in the wrong direction
    (commit `b8abac2`).
  - **scanf float conversions**: implement `%f`, `%F`, `%e`, `%E`, `%g`, `%G`,
    `%a`, `%A` in `scanString`. Parses sign, integer, fraction and exponent, then
    writes `float32` or `float64` according to the `l`/`L` length modifier.

  ### Debugging / test infrastructure

  - **diagThunk ring tracks `retEIP`**: each entry records the call site so
    per-frame debugging surfaces who actually invoked the API (commit `794ef5c`).
  - **`tests/test-amoeba.mjs`**: overrides `Sleep` and `PeekMessageA` so the
    synchronous headless loop doesn't stall on async rAF callbacks; auto-dismisses
    `MessageBoxA` and captures the first text/caption so the test fails loudly if
    the demo surfaces an error; reports pass/fail on "reached message loop"
    rather than the transient `waitingForMessage` flag. The harness reaches the
    message loop but the demo still errors out further along — investigation
    continues on a follow-up branch.
  - **`tests/inspect-*.mjs`**: small helpers to dump the amoeba PACK directory and
    locate the Vorbis identification header, inspect dialog resources, and inspect
    PE structures.

  ## Test plan

  - [ ] `npm run check` passes.
  - [ ] `timeout 2 npx tsx tests/test-amoeba.mjs` reaches the message loop (the
        demo is still expected to fail later — that's tracked separately).
  - [ ] Smoke-test an app that exercises ComboBox dropdowns (e.g. WINFILE) — no
        clipping regression.
  - [ ] Smoke-test an app that lists sound devices — picker is populated.
  - [ ] Smoke-test an FPU-heavy app — no regression from the FDIVP/FSUBP fix.
  - [ ] Smoke-test a CRT-using app that calls `sscanf` with `%f` / `%lf`.