### PR TITLE
Fix two Win16 paint-pipeline bugs (WM_PAINT storm, ValidateRect stub)

### DIFF
--- a/src/lib/emu/win16/user/message.ts
+++ b/src/lib/emu/win16/user/message.ts
@@ -572,6 +572,11 @@ export function registerWin16UserMessage(emu: Emulator, user: Win16Module, h: Wi
           emu.memory.writeU32(lpMsg + 10, Date.now() & 0xFFFFFFFF);
           return 1;
         }
+        // Clear needsPaint at synthesis time to prevent an infinite WM_PAINT
+        // storm when the WndProc paints via GetDC instead of BeginPaint (legal
+        // in Win16). Mirrors win32 synthesizePaint(); BeginPaint also clears it
+        // for the well-behaved case.
+        wnd.needsPaint = false;
         emu.memory.writeU16(lpMsg, handle);
         emu.memory.writeU16(lpMsg + 2, 0x000F); // WM_PAINT
         emu.memory.writeU16(lpMsg + 4, 0);

--- a/src/lib/emu/win16/user/paint.ts
+++ b/src/lib/emu/win16/user/paint.ts
@@ -168,5 +168,17 @@ export function registerWin16UserPaint(emu: Emulator, user: Win16Module, h: Win1
   // ───────────────────────────────────────────────────────────────────────────
   // Ordinal 127: ValidateRect(hWnd, lpRect) — 6 bytes (2+4)
   // ───────────────────────────────────────────────────────────────────────────
-  user.register('ValidateRect', 6, () => 1, 127);
+  // Clear the pending paint/erase flags (mirrors win32 ValidateRect). The stub
+  // `() => 1` left needsPaint set, so an app that validated its own region kept
+  // getting WM_PAINT re-synthesized. lpRect is ignored — we track a whole-window
+  // invalid flag, not a region, same as InvalidateRect here.
+  user.register('ValidateRect', 6, () => {
+    const [hWnd] = emu.readPascalArgs16([2, 4]);
+    const wnd = emu.handles.get<WindowInfo>(hWnd);
+    if (wnd) {
+      wnd.needsPaint = false;
+      wnd.needsErase = false;
+    }
+    return 1;
+  }, 127);
 }


### PR DESCRIPTION
  ## Summary

  Two correctness fixes for the Win16 (NE) paint/message pipeline, ported
  from the equivalent logic already present on the Win32 side. Both are
  generic — they apply to any Win16 application, not a specific one.

  The Win16 `user/` message and paint code was written before the Win32
  paint pipeline was hardened and had drifted from it. This brings the two
  shared behaviours back in line.

  ## Fixes

  - **Stop an infinite WM_PAINT storm** (`src/lib/emu/win16/user/message.ts`)
    `GetMessage` synthesised `WM_PAINT` for a window flagged `needsPaint` but
    never cleared the flag. If the app's `WndProc` repaints with `GetDC`
    instead of `BeginPaint` (perfectly legal in Win16), the flag stayed set
    and `WM_PAINT` was re-synthesised forever, starving the message loop.
    Now `needsPaint` is cleared at synthesis time, mirroring the Win32
    `synthesizePaint()` helper. `BeginPaint` still clears the flag for the
    well-behaved case, so nothing changes for apps that do call it.

  - **Implement `ValidateRect`** (`src/lib/emu/win16/user/paint.ts`)
    It was a no-op stub `() => 1`, so an app that validated its own update
    region kept receiving re-synthesised `WM_PAINT`. It now clears
    `needsPaint`/`needsErase`, mirroring the Win32 `ValidateRect`. (The
    `lpRect` argument is ignored — like `InvalidateRect` here, invalidation
    is tracked as a whole-window flag rather than a region.)

  ## Testing

  - `npm run build` passes.
  - Win16 KERNEL registry/profile integration suite: 47/47 pass.
  - No-regression verified headless against the real WINFILE.EXE (+ COMMCTRL,
    VER, SCONFIG companion DLLs): it boots to the message loop with its
    WFS_Frame main window and all four frame children (MDIClient, WFS_Drives,
    ToolbarWindow, status bar) laid out and settled (needsPaint=false).

  Note: WINFILE paints via BeginPaint, so it exercises the no-regression path
  but cannot itself reproduce the WM_PAINT storm (which only happens for a
  WndProc that paints with GetDC and never calls BeginPaint). That scenario
  is covered by mirroring the validated Win32 synthesizePaint()/ValidateRect
  logic.